### PR TITLE
add github action for test/lint/release helm charts

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,0 +1,25 @@
+name: Lint and Test Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.0.0-alpha.2
+        with:
+          installLocalPathProvisioner: true
+
+      - name: Run chart-testing (lint)
+        uses: helm/chart-testing-action@v1.0.0-alpha.1
+        with:
+          command: lint
+
+      - name: Run chart-testing (install)
+        uses: helm/chart-testing-action@v1.0.0-alpha.1
+        with:
+          command: install

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,38 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      # See https://github.com/helm/chart-releaser-action/issues/6
+      # For now, install the same version of Tiller as the chart-testing Helm
+      # client version: v2.15.2.
+      - name: Install Helm
+        run: |
+          curl -sSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get
+          chmod 700 get_helm.sh
+          DESIRED_VERSION=v2.15.2 ./get_helm.sh
+          helm init --client-only
+
+      - name: Add dependency chart repos
+        run: |
+          helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+          helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.0.0-alpha.1
+        env:
+          CR_TOKEN: "${{ secrets.CR_TOKEN }}"

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,7 @@
+# See https://github.com/helm/chart-testing#configuration
+remote: origin
+chart-dirs:
+  - charts
+chart-repos:
+  - incubator=https://kubernetes-charts-incubator.storage.googleapis.com
+helm-extra-args: --timeout=500


### PR DESCRIPTION
We need to setup this in the settings:
https://github.com/helm/chart-releaser-action#pre-requisites

@carlisia 