### PR TITLE
Correct the location name

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.2.0
 description: A Helm chart for velero
 name: velero
-version: 2.7.9
+version: 2.7.10
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/backupstoragelocation.yaml
+++ b/charts/velero/templates/backupstoragelocation.yaml
@@ -9,8 +9,8 @@ metadata:
     helm.sh/chart: {{ include "velero.chart" . }}
 spec:
 {{- with .Values.configuration }}
+  provider: {{ .provider }}
 {{- with .backupStorageLocation }}
-  provider: {{ .name  }}
   objectStorage:
     bucket: {{ .bucket  }}
     {{- with .prefix }}

--- a/charts/velero/templates/volumesnapshotlocation.yaml
+++ b/charts/velero/templates/volumesnapshotlocation.yaml
@@ -10,8 +10,8 @@ metadata:
     helm.sh/chart: {{ include "velero.chart" . }}
 spec:
 {{- with .Values.configuration }}
+  provider: {{ .provider }}
 {{- with .volumeSnapshotLocation }}
-  provider: {{ .name }}
 {{ with .config }}
   config:
   {{- with .region }}


### PR DESCRIPTION
The backup-location and snapshot-location should be the it's name,
not the provider name. And the provider name should be it's name,
not the name default.

This change enhances after helm install, use `velero backup-location get`
and `velero snapshot-location get`, the NAME and PROVIDER fields are the
user's input.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>