### PR TITLE
RBAC: decouple cluster role binding from namespaced role/rolebinding.

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.2.0
 description: A Helm chart for velero
 name: velero
-version: 2.7.10
+version: 2.8.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/README.md
+++ b/charts/velero/README.md
@@ -2,7 +2,7 @@
 
 Velero is an open source tool to safely backup and restore, perform disaster recovery, and migrate Kubernetes cluster resources and persistent volumes.
 
-Velero has two main components: a CLI, and a server-side Kubernetes deployment. 
+Velero has two main components: a CLI, and a server-side Kubernetes deployment.
 
 ## Installing the Velero CLI
 
@@ -14,7 +14,7 @@ This helm chart installs Velero version v1.2.0 https://github.com/vmware-tanzu/v
 
 ### Prerequisites
 
-#### Tiller cluster-admin permissions
+#### If using Helm 2: Tiller cluster-admin permissions
 
 A service account and the role binding prerequisite must be added to Tiller when configuring Helm to install Velero:
 

--- a/charts/velero/templates/clusterrole.yaml
+++ b/charts/velero/templates/clusterrole.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: {{ include "velero.fullname" . }}-server
   labels:
@@ -14,7 +14,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
     name: {{ include "velero.serverServiceAccount" . }}
 roleRef:
-  kind: ClusterRole
-  name: cluster-admin
+  kind: Role
+  name: {{ include "velero.fullname" . }}-server
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/velero/templates/clusterrolebinding.yaml
+++ b/charts/velero/templates/clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.rbac.create .Values.rbac.clusterAdministrator }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "velero.fullname" . }}-server
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+subjects:
+  - kind: ServiceAccount
+    namespace: {{ .Release.Namespace }}
+    name: {{ include "velero.serverServiceAccount" . }}
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/velero/templates/role.yaml
+++ b/charts/velero/templates/role.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "velero.fullname" . }}-server
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+rules:
+- apiGroups:
+    - "*"
+  resources:
+    - "*"
+  verbs:
+    - "*"
+
+{{- end }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -140,9 +140,11 @@ configuration:
 ## Settings for additional Velero resources.
 ##
 
-# Whether to create the Velero cluster role binding.
 rbac:
+  # Whether to create the Velero role and role binding to give all permissions to the namespace to Velero.
   create: true
+  # Whether to create the cluster role binding to give administrator permissions to Velero
+  clusterAdministrator: true
 
 # Information about the Kubernetes service account Velero uses.
 serviceAccount:


### PR DESCRIPTION
Allows to have a namespaced Velero without cluster admin access or with externally setup ClusterRole.