### PR TITLE
Adding support for Workload Identity in backups

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.2.0
 description: A Helm chart for velero
 name: velero
-version: 2.8.1
+version: 2.8.2
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/backupstoragelocation.yaml
+++ b/charts/velero/templates/backupstoragelocation.yaml
@@ -44,6 +44,11 @@ spec:
     publicUrl: {{ . }}
   {{- end }}
   {{- end }}
+  {{- if .serviceAccount }}
+  {{- with .serviceAccount }}
+    serviceAccount: {{ . }}
+  {{- end }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -90,6 +90,9 @@ configuration:
     #  subscriptionId:
     #  storageAccount:
     #  publicUrl:
+    #  Name of the GCP service account to use for this backup storage location. Specify the
+    #  service account here if you want to use workload identity instead of providing the key file.(GCP only)
+    #  serviceAccount:
 
   # Parameters for the `default` VolumeSnapshotLocation. See
   # https://velero.io/docs/v1.0.0/api-types/volumesnapshotlocation/


### PR DESCRIPTION
Allows GCP Workload Identity support in default backup storage location by adding the serviceAccount key in config, as specified here https://github.com/vmware-tanzu/velero-plugin-for-gcp/blob/master/backupstoragelocation.md