### PR TITLE
Support not create a default backup location

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.2.0
 description: A Helm chart for velero
 name: velero
-version: 2.8.7
+version: 2.8.8
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/backupstoragelocation.yaml
+++ b/charts/velero/templates/backupstoragelocation.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.backupsEnabled }}
 apiVersion: velero.io/v1
 kind: BackupStorageLocation
 metadata:
@@ -49,6 +50,7 @@ spec:
     serviceAccount: {{ . }}
   {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -172,7 +172,9 @@ credentials:
   # of your IAM credentials file.
   secretContents: {}
 
-# Wheter to create volumesnapshotlocation crd, if false => disable snapshot feature
+# Whether to create backupstoragelocation crd, if false => do not create a default backup location
+backupsEnabled: true
+# Whether to create volumesnapshotlocation crd, if false => disable snapshot feature
 snapshotsEnabled: true
 
 # Whether to deploy the restic daemonset.


### PR DESCRIPTION
Add flag _backupsEnabled_ to control whether to create a default backup location or not.
Like velero install `--no-default-backup-location` does.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>