### PR TITLE
fix: Add securityContext to give to the pod the right permissions to access AWS EKS IAM Roles for Service Accounts token

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.2.0
 description: A Helm chart for velero
 name: velero
-version: 2.8.1
+version: 2.8.2
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -34,6 +34,8 @@ spec:
     {{- end }}
     spec:
       restartPolicy: Always
+      securityContext:
+        fsGroup: 65534
       serviceAccountName: {{ include "velero.serverServiceAccount" . }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ include "velero.priorityClassName" . }}


### PR DESCRIPTION
fix: Add securityContext to give to the pod the right permissions to access AWS EKS IAM Roles for Service Accounts token

Signed-off-by: Bruno Galindro da Costa <bruno.galindro@gmail.com>

Fixes https://github.com/vmware-tanzu/helm-charts/issues/34
