### PR TITLE
Correct restic daemonset name

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.2.0
 description: A Helm chart for velero
 name: velero
-version: 2.8.6
+version: 2.8.7
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/restic-daemonset.yaml
+++ b/charts/velero/templates/restic-daemonset.yaml
@@ -49,7 +49,7 @@ spec:
         {{- toYaml .Values.restic.extraVolumes | nindent 8 }}
         {{- end }}
       containers:
-        - name: velero
+        - name: restic
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:


### PR DESCRIPTION
Align with `velero install`.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>