### PR TITLE
feat(velero): support pull secrets in deployment

### DIFF
--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     {{- end }}
-    spec:
+    spec: 
       restartPolicy: Always
       serviceAccountName: {{ include "velero.serverServiceAccount" . }}
       {{- if .Values.priorityClassName }}
@@ -138,6 +138,10 @@ spec:
     {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- with .Values.tolerations }}
       tolerations:

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -9,6 +9,8 @@ image:
   tag: v1.2.0
   pullPolicy: IfNotPresent
 
+imagePullSecrets: []
+
 # Annotations to add to the Velero deployment's pod template. Optional.
 #
 # If using kube2iam or kiam, use the following annotation with your AWS_ACCOUNT_ID


### PR DESCRIPTION
Signed-off-by: agill17 <amrit.gill@coveros.com>

Why?
When creating custom plugins, we could have images stored in a private repository, therefore.