### PR TITLE
Add LD_LIBRARY_PATH to deployment

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.3.1
 description: A Helm chart for velero
 name: velero
-version: 2.9.5
+version: 2.9.6
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -95,6 +95,8 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+            - name: LD_LIBRARY_PATH
+              value: /plugins
           {{- if .Values.credentials.useSecret }}
             {{- if eq $provider "aws" }}
             - name: AWS_SHARED_CREDENTIALS_FILE


### PR DESCRIPTION
This already merged to velero in https://github.com/vmware-tanzu/velero/pull/1893. 
Make helm chart deployment consistent and able to use for vsphere plugin.

Signed-off-by: Chin-Ya Huang <chin-ya.huang@suse.com>