### PR TITLE
adding insecureSkipTLSVerify

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.3.0
 description: A Helm chart for velero
 name: velero
-version: 2.9.2
+version: 2.9.3
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/backupstoragelocation.yaml
+++ b/charts/velero/templates/backupstoragelocation.yaml
@@ -50,6 +50,11 @@ spec:
     serviceAccount: {{ . }}
   {{- end }}
   {{- end }}
+  {{- if .insecureSkipTLSVerify }}
+  {{- with .insecureSkipTLSVerify }}
+    insecureSkipTLSVerify: {{ . }}
+  {{- end }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
the flag insecureSkipTLSVerify was added to velero under PR vmware-tanzu/velero#1769 .
When setting the flag under backupStorageLocation it is currently ignored.
https://github.com/vmware-tanzu/helm-charts/issues/77