### PR TITLE
Make CRDs Helm 3 compatiable

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.3.1
 description: A Helm chart for velero
 name: velero
-version: 2.9.6
+version: 2.9.7
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/ci/test-values.yaml
+++ b/charts/velero/ci/test-values.yaml
@@ -1,3 +1,5 @@
+installCRDs: false
+
 # Set provider name and backup storage location bucket name
 configuration:
   provider: aws

--- a/charts/velero/crds/backups.yaml
+++ b/charts/velero/crds/backups.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: velero
   annotations:
-    "helm.sh/hook": crd-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   group: velero.io

--- a/charts/velero/crds/backupstoragelocations.yaml
+++ b/charts/velero/crds/backupstoragelocations.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": crd-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   group: velero.io

--- a/charts/velero/crds/deletebackuprequests.yaml
+++ b/charts/velero/crds/deletebackuprequests.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": crd-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   group: velero.io

--- a/charts/velero/crds/downloadrequests.yaml
+++ b/charts/velero/crds/downloadrequests.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": crd-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   group: velero.io

--- a/charts/velero/crds/podvolumebackups.yaml
+++ b/charts/velero/crds/podvolumebackups.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": crd-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   group: velero.io

--- a/charts/velero/crds/podvolumerestores.yaml
+++ b/charts/velero/crds/podvolumerestores.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": crd-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   group: velero.io

--- a/charts/velero/crds/resticrepositories.yaml
+++ b/charts/velero/crds/resticrepositories.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": crd-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   group: velero.io

--- a/charts/velero/crds/restores.yaml
+++ b/charts/velero/crds/restores.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: velero
   annotations:
-    "helm.sh/hook": crd-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   group: velero.io

--- a/charts/velero/crds/schedules.yaml
+++ b/charts/velero/crds/schedules.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": crd-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   group: velero.io

--- a/charts/velero/crds/serverstatusrequests.yaml
+++ b/charts/velero/crds/serverstatusrequests.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": crd-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   group: velero.io

--- a/charts/velero/crds/volumesnapshotlocations.yaml
+++ b/charts/velero/crds/volumesnapshotlocations.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": crd-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   group: velero.io

--- a/charts/velero/templates/crds.yaml
+++ b/charts/velero/templates/crds.yaml
@@ -1,5 +1,0 @@
-{{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
-{{ $.Files.Get $path }}
----
-{{- end }}
-

--- a/charts/velero/templates/crds/backups.yaml
+++ b/charts/velero/templates/crds/backups.yaml
@@ -1,0 +1,392 @@
+{{- if .Values.installCRDs }}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: backups.velero.io
+  labels:
+    app.kubernetes.io/name: velero
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: velero.io
+  names:
+    kind: Backup
+    listKind: BackupList
+    plural: backups
+    singular: backup
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: Backup is a Velero resource that respresents the capture of Kubernetes
+        cluster state at a point in time (API objects and associated volume state).
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: BackupSpec defines the specification for a Velero backup.
+          properties:
+            excludedNamespaces:
+              description: ExcludedNamespaces contains a list of namespaces that are
+                not included in the backup.
+              items:
+                type: string
+              nullable: true
+              type: array
+            excludedResources:
+              description: ExcludedResources is a slice of resource names that are
+                not included in the backup.
+              items:
+                type: string
+              nullable: true
+              type: array
+            hooks:
+              description: Hooks represent custom behaviors that should be executed
+                at different phases of the backup.
+              properties:
+                resources:
+                  description: Resources are hooks that should be executed when backing
+                    up individual instances of a resource.
+                  items:
+                    description: BackupResourceHookSpec defines one or more BackupResourceHooks
+                      that should be executed based on the rules defined for namespaces,
+                      resources, and label selector.
+                    properties:
+                      excludedNamespaces:
+                        description: ExcludedNamespaces specifies the namespaces to
+                          which this hook spec does not apply.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      excludedResources:
+                        description: ExcludedResources specifies the resources to
+                          which this hook spec does not apply.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      includedNamespaces:
+                        description: IncludedNamespaces specifies the namespaces to
+                          which this hook spec applies. If empty, it applies to all
+                          namespaces.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      includedResources:
+                        description: IncludedResources specifies the resources to
+                          which this hook spec applies. If empty, it applies to all
+                          resources.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      labelSelector:
+                        description: LabelSelector, if specified, filters the resources
+                          to which this hook spec applies.
+                        nullable: true
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      name:
+                        description: Name is the name of this hook.
+                        type: string
+                      post:
+                        description: PostHooks is a list of BackupResourceHooks to
+                          execute after storing the item in the backup. These are
+                          executed after all "additional items" from item actions
+                          are processed.
+                        items:
+                          description: BackupResourceHook defines a hook for a resource.
+                          properties:
+                            exec:
+                              description: Exec defines an exec hook.
+                              properties:
+                                command:
+                                  description: Command is the command and arguments
+                                    to execute.
+                                  items:
+                                    type: string
+                                  minItems: 1
+                                  type: array
+                                container:
+                                  description: Container is the container in the pod
+                                    where the command should be executed. If not specified,
+                                    the pod's first container is used.
+                                  type: string
+                                onError:
+                                  description: OnError specifies how Velero should
+                                    behave if it encounters an error executing this
+                                    hook.
+                                  enum:
+                                  - Continue
+                                  - Fail
+                                  type: string
+                                timeout:
+                                  description: Timeout defines the maximum amount
+                                    of time Velero should wait for the hook to complete
+                                    before considering the execution a failure.
+                                  type: string
+                              required:
+                              - command
+                              type: object
+                          required:
+                          - exec
+                          type: object
+                        type: array
+                      pre:
+                        description: PreHooks is a list of BackupResourceHooks to
+                          execute prior to storing the item in the backup. These are
+                          executed before any "additional items" from item actions
+                          are processed.
+                        items:
+                          description: BackupResourceHook defines a hook for a resource.
+                          properties:
+                            exec:
+                              description: Exec defines an exec hook.
+                              properties:
+                                command:
+                                  description: Command is the command and arguments
+                                    to execute.
+                                  items:
+                                    type: string
+                                  minItems: 1
+                                  type: array
+                                container:
+                                  description: Container is the container in the pod
+                                    where the command should be executed. If not specified,
+                                    the pod's first container is used.
+                                  type: string
+                                onError:
+                                  description: OnError specifies how Velero should
+                                    behave if it encounters an error executing this
+                                    hook.
+                                  enum:
+                                  - Continue
+                                  - Fail
+                                  type: string
+                                timeout:
+                                  description: Timeout defines the maximum amount
+                                    of time Velero should wait for the hook to complete
+                                    before considering the execution a failure.
+                                  type: string
+                              required:
+                              - command
+                              type: object
+                          required:
+                          - exec
+                          type: object
+                        type: array
+                    required:
+                    - name
+                    type: object
+                  nullable: true
+                  type: array
+              type: object
+            includeClusterResources:
+              description: IncludeClusterResources specifies whether cluster-scoped
+                resources should be included for consideration in the backup.
+              nullable: true
+              type: boolean
+            includedNamespaces:
+              description: IncludedNamespaces is a slice of namespace names to include
+                objects from. If empty, all namespaces are included.
+              items:
+                type: string
+              nullable: true
+              type: array
+            includedResources:
+              description: IncludedResources is a slice of resource names to include
+                in the backup. If empty, all resources are included.
+              items:
+                type: string
+              nullable: true
+              type: array
+            labelSelector:
+              description: LabelSelector is a metav1.LabelSelector to filter with
+                when adding individual objects to the backup. If empty or nil, all
+                objects are included. Optional.
+              nullable: true
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            snapshotVolumes:
+              description: SnapshotVolumes specifies whether to take cloud snapshots
+                of any PV's referenced in the set of objects included in the Backup.
+              nullable: true
+              type: boolean
+            storageLocation:
+              description: StorageLocation is a string containing the name of a BackupStorageLocation
+                where the backup should be stored.
+              type: string
+            ttl:
+              description: TTL is a time.Duration-parseable string describing how
+                long the Backup should be retained for.
+              type: string
+            volumeSnapshotLocations:
+              description: VolumeSnapshotLocations is a list containing names of VolumeSnapshotLocations
+                associated with this backup.
+              items:
+                type: string
+              type: array
+          type: object
+        status:
+          description: BackupStatus captures the current status of a Velero backup.
+          properties:
+            completionTimestamp:
+              description: CompletionTimestamp records the time a backup was completed.
+                Completion time is recorded even on failed backups. Completion time
+                is recorded before uploading the backup object. The server's time
+                is used for CompletionTimestamps
+              format: date-time
+              nullable: true
+              type: string
+            errors:
+              description: Errors is a count of all error messages that were generated
+                during execution of the backup.  The actual errors are in the backup's
+                log file in object storage.
+              type: integer
+            expiration:
+              description: Expiration is when this Backup is eligible for garbage-collection.
+              format: date-time
+              nullable: true
+              type: string
+            phase:
+              description: Phase is the current state of the Backup.
+              enum:
+              - New
+              - FailedValidation
+              - InProgress
+              - Completed
+              - PartiallyFailed
+              - Failed
+              - Deleting
+              type: string
+            startTimestamp:
+              description: StartTimestamp records the time a backup was started. Separate
+                from CreationTimestamp, since that value changes on restores. The
+                server's time is used for StartTimestamps
+              format: date-time
+              nullable: true
+              type: string
+            validationErrors:
+              description: ValidationErrors is a slice of all validation errors (if
+                applicable).
+              items:
+                type: string
+              nullable: true
+              type: array
+            version:
+              description: Version is the backup format version.
+              type: integer
+            volumeSnapshotsAttempted:
+              description: VolumeSnapshotsAttempted is the total number of attempted
+                volume snapshots for this backup.
+              type: integer
+            volumeSnapshotsCompleted:
+              description: VolumeSnapshotsCompleted is the total number of successfully
+                completed volume snapshots for this backup.
+              type: integer
+            warnings:
+              description: Warnings is a count of all warning messages that were generated
+                during execution of the backup. The actual warnings are in the backup's
+                log file in object storage.
+              type: integer
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+{{- end }}

--- a/charts/velero/templates/crds/backupstoragelocations.yaml
+++ b/charts/velero/templates/crds/backupstoragelocations.yaml
@@ -1,0 +1,117 @@
+{{- if .Values.installCRDs }}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: backupstoragelocations.velero.io
+  labels:
+    app.kubernetes.io/name: "velero"
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: velero.io
+  names:
+    kind: BackupStorageLocation
+    listKind: BackupStorageLocationList
+    plural: backupstoragelocations
+    singular: backupstoragelocation
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: BackupStorageLocation is a location where Velero stores backup
+        objects.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: BackupStorageLocationSpec defines the specification for a Velero
+            BackupStorageLocation.
+          properties:
+            accessMode:
+              description: AccessMode defines the permissions for the backup storage
+                location.
+              enum:
+              - ReadOnly
+              - ReadWrite
+              type: string
+            backupSyncPeriod:
+              description: BackupSyncPeriod defines how frequently to sync backup
+                API objects from object storage. A value of 0 disables sync.
+              nullable: true
+              type: string
+            config:
+              additionalProperties:
+                type: string
+              description: Config is for provider-specific configuration fields.
+              type: object
+            objectStorage:
+              description: ObjectStorageLocation specifies the settings necessary
+                to connect to a provider's object storage.
+              properties:
+                bucket:
+                  description: Bucket is the bucket to use for object storage.
+                  type: string
+                prefix:
+                  description: Prefix is the path inside a bucket to use for Velero
+                    storage. Optional.
+                  type: string
+              required:
+              - bucket
+              type: object
+            provider:
+              description: Provider is the provider of the backup storage.
+              type: string
+          required:
+          - objectStorage
+          - provider
+          type: object
+        status:
+          description: BackupStorageLocationStatus describes the current status of
+            a Velero BackupStorageLocation.
+          properties:
+            accessMode:
+              description: "AccessMode is an unused field. \n Deprecated: there is
+                now an AccessMode field on the Spec and this field will be removed
+                entirely as of v2.0."
+              enum:
+              - ReadOnly
+              - ReadWrite
+              type: string
+            lastSyncedRevision:
+              description: "LastSyncedRevision is the value of the `metadata/revision`
+                file in the backup storage location the last time the BSL's contents
+                were synced into the cluster. \n Deprecated: this field is no longer
+                updated or used for detecting changes to the location's contents and
+                will be removed entirely in v2.0."
+              type: string
+            lastSyncedTime:
+              description: LastSyncedTime is the last time the contents of the location
+                were synced into the cluster.
+              format: date-time
+              nullable: true
+              type: string
+            phase:
+              description: Phase is the current state of the BackupStorageLocation.
+              enum:
+              - Available
+              - Unavailable
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+{{- end }}

--- a/charts/velero/templates/crds/cleanup-crds.yaml
+++ b/charts/velero/templates/crds/cleanup-crds.yaml
@@ -1,6 +1,6 @@
 # This job is meant primarily for cleaning up on CI systems.
 # Using this on production systems, especially those that have multiple releases of Velero, will be destructive.
-{{- if .Values.cleanUpCRDs }}
+{{- if and .Values.installCDRs .Values.cleanUpCRDs  }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/velero/templates/crds/deletebackuprequests.yaml
+++ b/charts/velero/templates/crds/deletebackuprequests.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.installCRDs }}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: deletebackuprequests.velero.io
+  labels:
+    app.kubernetes.io/name: "velero"
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: velero.io
+  names:
+    kind: DeleteBackupRequest
+    listKind: DeleteBackupRequestList
+    plural: deletebackuprequests
+    singular: deletebackuprequest
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: DeleteBackupRequest is a request to delete one or more backups.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: DeleteBackupRequestSpec is the specification for which backups
+            to delete.
+          properties:
+            backupName:
+              type: string
+          required:
+          - backupName
+          type: object
+        status:
+          description: DeleteBackupRequestStatus is the current status of a DeleteBackupRequest.
+          properties:
+            errors:
+              description: Errors contains any errors that were encountered during
+                the deletion process.
+              items:
+                type: string
+              nullable: true
+              type: array
+            phase:
+              description: Phase is the current state of the DeleteBackupRequest.
+              enum:
+              - New
+              - InProgress
+              - Processed
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+{{- end }}

--- a/charts/velero/templates/crds/downloadrequests.yaml
+++ b/charts/velero/templates/crds/downloadrequests.yaml
@@ -1,0 +1,90 @@
+{{- if .Values.installCRDs }}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: downloadrequests.velero.io
+  labels:
+    app.kubernetes.io/name: "velero"
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: velero.io
+  names:
+    kind: DownloadRequest
+    listKind: DownloadRequestList
+    plural: downloadrequests
+    singular: downloadrequest
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: DownloadRequest is a request to download an artifact from backup
+        object storage, such as a backup log file.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: DownloadRequestSpec is the specification for a download request.
+          properties:
+            target:
+              description: Target is what to download (e.g. logs for a backup).
+              properties:
+                kind:
+                  description: Kind is the type of file to download.
+                  enum:
+                  - BackupLog
+                  - BackupContents
+                  - BackupVolumeSnapshots
+                  - BackupResourceList
+                  - RestoreLog
+                  - RestoreResults
+                  type: string
+                name:
+                  description: Name is the name of the kubernetes resource with which
+                    the file is associated.
+                  type: string
+              required:
+              - kind
+              - name
+              type: object
+          required:
+          - target
+          type: object
+        status:
+          description: DownloadRequestStatus is the current status of a DownloadRequest.
+          properties:
+            downloadURL:
+              description: DownloadURL contains the pre-signed URL for the target
+                file.
+              type: string
+            expiration:
+              description: Expiration is when this DownloadRequest expires and can
+                be deleted by the system.
+              format: date-time
+              nullable: true
+              type: string
+            phase:
+              description: Phase is the current state of the DownloadRequest.
+              enum:
+              - New
+              - Processed
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+{{- end }}

--- a/charts/velero/templates/crds/podvolumebackups.yaml
+++ b/charts/velero/templates/crds/podvolumebackups.yaml
@@ -1,0 +1,158 @@
+{{- if .Values.installCRDs }}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: podvolumebackups.velero.io
+  labels:
+    app.kubernetes.io/name: "velero"
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: velero.io
+  names:
+    kind: PodVolumeBackup
+    listKind: PodVolumeBackupList
+    plural: podvolumebackups
+    singular: podvolumebackup
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: PodVolumeBackupSpec is the specification for a PodVolumeBackup.
+          properties:
+            backupStorageLocation:
+              description: BackupStorageLocation is the name of the backup storage
+                location where the restic repository is stored.
+              type: string
+            node:
+              description: Node is the name of the node that the Pod is running on.
+              type: string
+            pod:
+              description: Pod is a reference to the pod containing the volume to
+                be backed up.
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+            repoIdentifier:
+              description: RepoIdentifier is the restic repository identifier.
+              type: string
+            tags:
+              additionalProperties:
+                type: string
+              description: Tags are a map of key-value pairs that should be applied
+                to the volume backup as tags.
+              type: object
+            volume:
+              description: Volume is the name of the volume within the Pod to be backed
+                up.
+              type: string
+          required:
+          - backupStorageLocation
+          - node
+          - pod
+          - repoIdentifier
+          - volume
+          type: object
+        status:
+          description: PodVolumeBackupStatus is the current status of a PodVolumeBackup.
+          properties:
+            completionTimestamp:
+              description: CompletionTimestamp records the time a backup was completed.
+                Completion time is recorded even on failed backups. Completion time
+                is recorded before uploading the backup object. The server's time
+                is used for CompletionTimestamps
+              format: date-time
+              nullable: true
+              type: string
+            message:
+              description: Message is a message about the pod volume backup's status.
+              type: string
+            path:
+              description: Path is the full path within the controller pod being backed
+                up.
+              type: string
+            phase:
+              description: Phase is the current state of the PodVolumeBackup.
+              enum:
+              - New
+              - InProgress
+              - Completed
+              - Failed
+              type: string
+            progress:
+              description: Progress holds the total number of bytes of the volume
+                and the current number of backed up bytes. This can be used to display
+                progress information about the backup operation.
+              properties:
+                bytesDone:
+                  format: int64
+                  type: integer
+                totalBytes:
+                  format: int64
+                  type: integer
+              type: object
+            snapshotID:
+              description: SnapshotID is the identifier for the snapshot of the pod
+                volume.
+              type: string
+            startTimestamp:
+              description: StartTimestamp records the time a backup was started. Separate
+                from CreationTimestamp, since that value changes on restores. The
+                server's time is used for StartTimestamps
+              format: date-time
+              nullable: true
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+{{- end }}

--- a/charts/velero/templates/crds/podvolumerestores.yaml
+++ b/charts/velero/templates/crds/podvolumerestores.yaml
@@ -1,0 +1,141 @@
+{{- if .Values.installCRDs }}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: podvolumerestores.velero.io
+  labels:
+    app.kubernetes.io/name: "velero"
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: velero.io
+  names:
+    kind: PodVolumeRestore
+    listKind: PodVolumeRestoreList
+    plural: podvolumerestores
+    singular: podvolumerestore
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: PodVolumeRestoreSpec is the specification for a PodVolumeRestore.
+          properties:
+            backupStorageLocation:
+              description: BackupStorageLocation is the name of the backup storage
+                location where the restic repository is stored.
+              type: string
+            pod:
+              description: Pod is a reference to the pod containing the volume to
+                be restored.
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+            repoIdentifier:
+              description: RepoIdentifier is the restic repository identifier.
+              type: string
+            snapshotID:
+              description: SnapshotID is the ID of the volume snapshot to be restored.
+              type: string
+            volume:
+              description: Volume is the name of the volume within the Pod to be restored.
+              type: string
+          required:
+          - backupStorageLocation
+          - pod
+          - repoIdentifier
+          - snapshotID
+          - volume
+          type: object
+        status:
+          description: PodVolumeRestoreStatus is the current status of a PodVolumeRestore.
+          properties:
+            completionTimestamp:
+              description: CompletionTimestamp records the time a restore was completed.
+                Completion time is recorded even on failed restores. The server's
+                time is used for CompletionTimestamps
+              format: date-time
+              nullable: true
+              type: string
+            message:
+              description: Message is a message about the pod volume restore's status.
+              type: string
+            phase:
+              description: Phase is the current state of the PodVolumeRestore.
+              enum:
+              - New
+              - InProgress
+              - Completed
+              - Failed
+              type: string
+            progress:
+              description: Progress holds the total number of bytes of the snapshot
+                and the current number of restored bytes. This can be used to display
+                progress information about the restore operation.
+              properties:
+                bytesDone:
+                  format: int64
+                  type: integer
+                totalBytes:
+                  format: int64
+                  type: integer
+              type: object
+            startTimestamp:
+              description: StartTimestamp records the time a restore was started.
+                The server's time is used for StartTimestamps
+              format: date-time
+              nullable: true
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+{{- end }}

--- a/charts/velero/templates/crds/resticrepositories.yaml
+++ b/charts/velero/templates/crds/resticrepositories.yaml
@@ -1,0 +1,85 @@
+{{- if .Values.installCRDs }}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: resticrepositories.velero.io
+  labels:
+    app.kubernetes.io/name: "velero"
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: velero.io
+  names:
+    kind: ResticRepository
+    listKind: ResticRepositoryList
+    plural: resticrepositories
+    singular: resticrepository
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ResticRepositorySpec is the specification for a ResticRepository.
+          properties:
+            backupStorageLocation:
+              description: BackupStorageLocation is the name of the BackupStorageLocation
+                that should contain this repository.
+              type: string
+            maintenanceFrequency:
+              description: MaintenanceFrequency is how often maintenance should be
+                run.
+              type: string
+            resticIdentifier:
+              description: ResticIdentifier is the full restic-compatible string for
+                identifying this repository.
+              type: string
+            volumeNamespace:
+              description: VolumeNamespace is the namespace this restic repository
+                contains pod volume backups for.
+              type: string
+          required:
+          - backupStorageLocation
+          - maintenanceFrequency
+          - resticIdentifier
+          - volumeNamespace
+          type: object
+        status:
+          description: ResticRepositoryStatus is the current status of a ResticRepository.
+          properties:
+            lastMaintenanceTime:
+              description: LastMaintenanceTime is the last time maintenance was run.
+              format: date-time
+              nullable: true
+              type: string
+            message:
+              description: Message is a message about the current status of the ResticRepository.
+              type: string
+            phase:
+              description: Phase is the current state of the ResticRepository.
+              enum:
+              - New
+              - Ready
+              - NotReady
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+{{- end }}

--- a/charts/velero/templates/crds/restores.yaml
+++ b/charts/velero/templates/crds/restores.yaml
@@ -1,0 +1,185 @@
+{{- if .Values.installCRDs }}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: restores.velero.io
+  labels:
+    app.kubernetes.io/name: velero
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: velero.io
+  names:
+    kind: Restore
+    listKind: RestoreList
+    plural: restores
+    singular: restore
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: Restore is a Velero resource that represents the application of
+        resources from a Velero backup to a target Kubernetes cluster.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: RestoreSpec defines the specification for a Velero restore.
+          properties:
+            backupName:
+              description: BackupName is the unique name of the Velero backup to restore
+                from.
+              type: string
+            excludedNamespaces:
+              description: ExcludedNamespaces contains a list of namespaces that are
+                not included in the restore.
+              items:
+                type: string
+              nullable: true
+              type: array
+            excludedResources:
+              description: ExcludedResources is a slice of resource names that are
+                not included in the restore.
+              items:
+                type: string
+              nullable: true
+              type: array
+            includeClusterResources:
+              description: IncludeClusterResources specifies whether cluster-scoped
+                resources should be included for consideration in the restore. If
+                null, defaults to true.
+              nullable: true
+              type: boolean
+            includedNamespaces:
+              description: IncludedNamespaces is a slice of namespace names to include
+                objects from. If empty, all namespaces are included.
+              items:
+                type: string
+              nullable: true
+              type: array
+            includedResources:
+              description: IncludedResources is a slice of resource names to include
+                in the restore. If empty, all resources in the backup are included.
+              items:
+                type: string
+              nullable: true
+              type: array
+            labelSelector:
+              description: LabelSelector is a metav1.LabelSelector to filter with
+                when restoring individual objects from the backup. If empty or nil,
+                all objects are included. Optional.
+              nullable: true
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            namespaceMapping:
+              additionalProperties:
+                type: string
+              description: NamespaceMapping is a map of source namespace names to
+                target namespace names to restore into. Any source namespaces not
+                included in the map will be restored into namespaces of the same name.
+              type: object
+            restorePVs:
+              description: RestorePVs specifies whether to restore all included PVs
+                from snapshot (via the cloudprovider).
+              nullable: true
+              type: boolean
+            scheduleName:
+              description: ScheduleName is the unique name of the Velero schedule
+                to restore from. If specified, and BackupName is empty, Velero will
+                restore from the most recent successful backup created from this schedule.
+              type: string
+          required:
+          - backupName
+          type: object
+        status:
+          description: RestoreStatus captures the current status of a Velero restore
+          properties:
+            errors:
+              description: Errors is a count of all error messages that were generated
+                during execution of the restore. The actual errors are stored in object
+                storage.
+              type: integer
+            failureReason:
+              description: FailureReason is an error that caused the entire restore
+                to fail.
+              type: string
+            phase:
+              description: Phase is the current state of the Restore
+              enum:
+              - New
+              - FailedValidation
+              - InProgress
+              - Completed
+              - PartiallyFailed
+              - Failed
+              type: string
+            validationErrors:
+              description: ValidationErrors is a slice of all validation errors (if
+                applicable)
+              items:
+                type: string
+              nullable: true
+              type: array
+            warnings:
+              description: Warnings is a count of all warning messages that were generated
+                during execution of the restore. The actual warnings are stored in
+                object storage.
+              type: integer
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+{{- end }}

--- a/charts/velero/templates/crds/schedules.yaml
+++ b/charts/velero/templates/crds/schedules.yaml
@@ -1,0 +1,371 @@
+{{- if .Values.installCRDs }}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: schedules.velero.io
+  labels:
+    app.kubernetes.io/name: "velero"
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: velero.io
+  names:
+    kind: Schedule
+    listKind: ScheduleList
+    plural: schedules
+    singular: schedule
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: Schedule is a Velero resource that represents a pre-scheduled or
+        periodic Backup that should be run.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ScheduleSpec defines the specification for a Velero schedule
+          properties:
+            schedule:
+              description: Schedule is a Cron expression defining when to run the
+                Backup.
+              type: string
+            template:
+              description: Template is the definition of the Backup to be run on the
+                provided schedule
+              properties:
+                excludedNamespaces:
+                  description: ExcludedNamespaces contains a list of namespaces that
+                    are not included in the backup.
+                  items:
+                    type: string
+                  nullable: true
+                  type: array
+                excludedResources:
+                  description: ExcludedResources is a slice of resource names that
+                    are not included in the backup.
+                  items:
+                    type: string
+                  nullable: true
+                  type: array
+                hooks:
+                  description: Hooks represent custom behaviors that should be executed
+                    at different phases of the backup.
+                  properties:
+                    resources:
+                      description: Resources are hooks that should be executed when
+                        backing up individual instances of a resource.
+                      items:
+                        description: BackupResourceHookSpec defines one or more BackupResourceHooks
+                          that should be executed based on the rules defined for namespaces,
+                          resources, and label selector.
+                        properties:
+                          excludedNamespaces:
+                            description: ExcludedNamespaces specifies the namespaces
+                              to which this hook spec does not apply.
+                            items:
+                              type: string
+                            nullable: true
+                            type: array
+                          excludedResources:
+                            description: ExcludedResources specifies the resources
+                              to which this hook spec does not apply.
+                            items:
+                              type: string
+                            nullable: true
+                            type: array
+                          includedNamespaces:
+                            description: IncludedNamespaces specifies the namespaces
+                              to which this hook spec applies. If empty, it applies
+                              to all namespaces.
+                            items:
+                              type: string
+                            nullable: true
+                            type: array
+                          includedResources:
+                            description: IncludedResources specifies the resources
+                              to which this hook spec applies. If empty, it applies
+                              to all resources.
+                            items:
+                              type: string
+                            nullable: true
+                            type: array
+                          labelSelector:
+                            description: LabelSelector, if specified, filters the
+                              resources to which this hook spec applies.
+                            nullable: true
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          name:
+                            description: Name is the name of this hook.
+                            type: string
+                          post:
+                            description: PostHooks is a list of BackupResourceHooks
+                              to execute after storing the item in the backup. These
+                              are executed after all "additional items" from item
+                              actions are processed.
+                            items:
+                              description: BackupResourceHook defines a hook for a
+                                resource.
+                              properties:
+                                exec:
+                                  description: Exec defines an exec hook.
+                                  properties:
+                                    command:
+                                      description: Command is the command and arguments
+                                        to execute.
+                                      items:
+                                        type: string
+                                      minItems: 1
+                                      type: array
+                                    container:
+                                      description: Container is the container in the
+                                        pod where the command should be executed.
+                                        If not specified, the pod's first container
+                                        is used.
+                                      type: string
+                                    onError:
+                                      description: OnError specifies how Velero should
+                                        behave if it encounters an error executing
+                                        this hook.
+                                      enum:
+                                      - Continue
+                                      - Fail
+                                      type: string
+                                    timeout:
+                                      description: Timeout defines the maximum amount
+                                        of time Velero should wait for the hook to
+                                        complete before considering the execution
+                                        a failure.
+                                      type: string
+                                  required:
+                                  - command
+                                  type: object
+                              required:
+                              - exec
+                              type: object
+                            type: array
+                          pre:
+                            description: PreHooks is a list of BackupResourceHooks
+                              to execute prior to storing the item in the backup.
+                              These are executed before any "additional items" from
+                              item actions are processed.
+                            items:
+                              description: BackupResourceHook defines a hook for a
+                                resource.
+                              properties:
+                                exec:
+                                  description: Exec defines an exec hook.
+                                  properties:
+                                    command:
+                                      description: Command is the command and arguments
+                                        to execute.
+                                      items:
+                                        type: string
+                                      minItems: 1
+                                      type: array
+                                    container:
+                                      description: Container is the container in the
+                                        pod where the command should be executed.
+                                        If not specified, the pod's first container
+                                        is used.
+                                      type: string
+                                    onError:
+                                      description: OnError specifies how Velero should
+                                        behave if it encounters an error executing
+                                        this hook.
+                                      enum:
+                                      - Continue
+                                      - Fail
+                                      type: string
+                                    timeout:
+                                      description: Timeout defines the maximum amount
+                                        of time Velero should wait for the hook to
+                                        complete before considering the execution
+                                        a failure.
+                                      type: string
+                                  required:
+                                  - command
+                                  type: object
+                              required:
+                              - exec
+                              type: object
+                            type: array
+                        required:
+                        - name
+                        type: object
+                      nullable: true
+                      type: array
+                  type: object
+                includeClusterResources:
+                  description: IncludeClusterResources specifies whether cluster-scoped
+                    resources should be included for consideration in the backup.
+                  nullable: true
+                  type: boolean
+                includedNamespaces:
+                  description: IncludedNamespaces is a slice of namespace names to
+                    include objects from. If empty, all namespaces are included.
+                  items:
+                    type: string
+                  nullable: true
+                  type: array
+                includedResources:
+                  description: IncludedResources is a slice of resource names to include
+                    in the backup. If empty, all resources are included.
+                  items:
+                    type: string
+                  nullable: true
+                  type: array
+                labelSelector:
+                  description: LabelSelector is a metav1.LabelSelector to filter with
+                    when adding individual objects to the backup. If empty or nil,
+                    all objects are included. Optional.
+                  nullable: true
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                snapshotVolumes:
+                  description: SnapshotVolumes specifies whether to take cloud snapshots
+                    of any PV's referenced in the set of objects included in the Backup.
+                  nullable: true
+                  type: boolean
+                storageLocation:
+                  description: StorageLocation is a string containing the name of
+                    a BackupStorageLocation where the backup should be stored.
+                  type: string
+                ttl:
+                  description: TTL is a time.Duration-parseable string describing
+                    how long the Backup should be retained for.
+                  type: string
+                volumeSnapshotLocations:
+                  description: VolumeSnapshotLocations is a list containing names
+                    of VolumeSnapshotLocations associated with this backup.
+                  items:
+                    type: string
+                  type: array
+              type: object
+          required:
+          - schedule
+          - template
+          type: object
+        status:
+          description: ScheduleStatus captures the current state of a Velero schedule
+          properties:
+            lastBackup:
+              description: LastBackup is the last time a Backup was run for this Schedule
+                schedule
+              format: date-time
+              nullable: true
+              type: string
+            phase:
+              description: Phase is the current phase of the Schedule
+              enum:
+              - New
+              - Enabled
+              - FailedValidation
+              type: string
+            validationErrors:
+              description: ValidationErrors is a slice of all validation errors (if
+                applicable)
+              items:
+                type: string
+              type: array
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+{{- end }}

--- a/charts/velero/templates/crds/serverstatusrequests.yaml
+++ b/charts/velero/templates/crds/serverstatusrequests.yaml
@@ -1,0 +1,81 @@
+{{- if .Values.installCRDs }}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: serverstatusrequests.velero.io
+  labels:
+    app.kubernetes.io/name: "velero"
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: velero.io
+  names:
+    kind: ServerStatusRequest
+    listKind: ServerStatusRequestList
+    plural: serverstatusrequests
+    singular: serverstatusrequest
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: ServerStatusRequest is a request to access current status information
+        about the Velero server.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ServerStatusRequestSpec is the specification for a ServerStatusRequest.
+          type: object
+        status:
+          description: ServerStatusRequestStatus is the current status of a ServerStatusRequest.
+          properties:
+            phase:
+              description: Phase is the current lifecycle phase of the ServerStatusRequest.
+              enum:
+              - New
+              - Processed
+              type: string
+            plugins:
+              description: Plugins list information about the plugins running on the
+                Velero server
+              items:
+                description: PluginInfo contains attributes of a Velero plugin
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              nullable: true
+              type: array
+            processedTimestamp:
+              description: ProcessedTimestamp is when the ServerStatusRequest was
+                processed by the ServerStatusRequestController.
+              format: date-time
+              nullable: true
+              type: string
+            serverVersion:
+              description: ServerVersion is the Velero server version.
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+{{- end }}

--- a/charts/velero/templates/crds/volumesnapshotlocations.yaml
+++ b/charts/velero/templates/crds/volumesnapshotlocations.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.installCRDs }}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumesnapshotlocations.velero.io
+  labels:
+    app.kubernetes.io/name: "velero"
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: velero.io
+  names:
+    kind: VolumeSnapshotLocation
+    listKind: VolumeSnapshotLocationList
+    plural: volumesnapshotlocations
+    singular: volumesnapshotlocation
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: VolumeSnapshotLocation is a location where Velero stores volume
+        snapshots.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: VolumeSnapshotLocationSpec defines the specification for a
+            Velero VolumeSnapshotLocation.
+          properties:
+            config:
+              additionalProperties:
+                type: string
+              description: Config is for provider-specific configuration fields.
+              type: object
+            provider:
+              description: Provider is the provider of the volume storage.
+              type: string
+          required:
+          - provider
+          type: object
+        status:
+          description: VolumeSnapshotLocationStatus describes the current status of
+            a Velero VolumeSnapshotLocation.
+          properties:
+            phase:
+              description: VolumeSnapshotLocationPhase is the lifecyle phase of a
+                Velero VolumeSnapshotLocation.
+              enum:
+              - Available
+              - Unavailable
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+{{- end }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -61,6 +61,9 @@ metrics:
     enabled: false
     additionalLabels: {}
 
+# Install CRDs as a templates. Enabled by default.
+installCRDs: true
+
 ##
 ## End of deployment-related settings.
 ##


### PR DESCRIPTION
- Remove `"helm.sh/hook": crd-install` from `crds/*.yaml`
- Copy Helm v2 CRDs to `templates/crds`, gated by `installCRDs` value

Based on [argo-cd](https://github.com/argoproj/argo-helm/tree/master/charts/argo-cd) helm chart.

Closes https://github.com/vmware-tanzu/helm-charts/issues/7.