### PR TITLE
Fix timeout chart-testing parameter

### DIFF
--- a/ct.yaml
+++ b/ct.yaml
@@ -4,4 +4,4 @@ chart-dirs:
   - charts
 chart-repos:
   - incubator=https://kubernetes-charts-incubator.storage.googleapis.com
-helm-extra-args: --timeout=500
+helm-extra-args: --timeout=500s


### PR DESCRIPTION
As I understand a new version of `ct` introduced in the [last commit](https://github.com/vmware-tanzu/helm-charts/commit/be130a338420c2a6b12c8a3ac96b7d5e5ff7ea07) uses Helm v3 by default, which has a different `--timeout` argument format:

```
--timeout duration             time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
```

Chart testing will fail like #81 until PR will be merged.

Signed-off-by: Nikolai Iurin <yurinnick93@gmail.com>