### PR TITLE
[Security] Enable specifying docker image by digest in addition to tag

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.3.1
 description: A Helm chart for velero
 name: velero
-version: 2.9.8
+version: 2.9.9
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.3.1
 description: A Helm chart for velero
 name: velero
-version: 2.9.9
+version: 2.9.10
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -40,7 +40,11 @@ spec:
       {{- end }}
       containers:
         - name: velero
+      {{- if .Values.image.digest }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+      {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+      {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.metrics.enabled }}
           ports:

--- a/charts/velero/templates/restic-daemonset.yaml
+++ b/charts/velero/templates/restic-daemonset.yaml
@@ -50,7 +50,11 @@ spec:
         {{- end }}
       containers:
         - name: restic
+        {{- if .Values.image.digest }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+        {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /velero

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -7,6 +7,7 @@
 image:
   repository: velero/velero
   tag: v1.3.1
+  digest: sha256:0c74f1d552ef25a4227e582f4c0e6b3db3402abe196595ee9442ceeb43b99696
   pullPolicy: IfNotPresent
 
 # Annotations to add to the Velero deployment's pod template. Optional.


### PR DESCRIPTION
Signed-off-by: Ahmad Haj Ali <ahmad.haj.ali@sap.com>

Pulling images by digest ensures kubernetes cluster does not pull potentially compromised images from the source repository. 