### PR TITLE
Fixing toYaml generation

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.3.1
 description: A Helm chart for velero
 name: velero
-version: 2.9.11
+version: 2.9.12
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.3.1
 description: A Helm chart for velero
 name: velero
-version: 2.9.9
+version: 2.9.10
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.3.1
 description: A Helm chart for velero
 name: velero
-version: 2.9.10
+version: 2.9.11
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/ci/test-values.yaml
+++ b/charts/velero/ci/test-values.yaml
@@ -5,6 +5,14 @@ configuration:
   provider: aws
   backupStorageLocation:
     bucket: velero
+    config:
+      region: us-west-1
+      profile: test
+  volumeSnapshotLocation:
+    provider: aws
+    config:
+      bucket: velero
+      region: us-west-1
 
 # Set a service account so that the CRD clean up job has proper permissions to delete CRDs
 serviceAccount:

--- a/charts/velero/templates/backupstoragelocation.yaml
+++ b/charts/velero/templates/backupstoragelocation.yaml
@@ -16,9 +16,9 @@ spec:
     {{- with .prefix }}
     prefix: {{ . }}
     {{- end }}
-{{ with .config }}
+{{- with .config }}
   config:
-    {{ toYaml . }}
+{{ toYaml . | indent 4}}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/velero/templates/backupstoragelocation.yaml
+++ b/charts/velero/templates/backupstoragelocation.yaml
@@ -19,6 +19,9 @@ spec:
 {{- with .config }}
   config:
 {{ toYaml . | indent 4}}
+{{- if .s3ForcePathStyle }}
+    s3ForcePathStyle: {{ .s3ForcePathStyle | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/velero/templates/volumesnapshotlocation.yaml
+++ b/charts/velero/templates/volumesnapshotlocation.yaml
@@ -12,6 +12,6 @@ spec:
   provider: {{ include "velero.volumeSnapshotLocation.provider" . }}
 {{- with .Values.configuration.volumeSnapshotLocation.config }}
   config:
-{{- toYaml . | nindent 4 }}
+{{ toYaml . | indent 4 }}
 {{- end -}}
 {{- end }}

--- a/charts/velero/templates/volumesnapshotlocation.yaml
+++ b/charts/velero/templates/volumesnapshotlocation.yaml
@@ -12,6 +12,6 @@ spec:
   provider: {{ include "velero.volumeSnapshotLocation.provider" . }}
 {{- with .Values.configuration.volumeSnapshotLocation.config }}
   config:
-  {{ toYaml .config }}
+{{- toYaml . | nindent 4 }}
 {{- end -}}
 {{- end }}


### PR DESCRIPTION
This fixes the `toYaml` generation of the template and resolves issue #93, it appears that the release of version 2.9.9 of the chart causes issue with the template generation and the template doesn't seem to render if you use `{{ toYaml .config }}`

This fix actually renders the template locally after removing the `.config`

Fixes https://github.com/vmware-tanzu/helm-charts/issues/93.