### PR TITLE
Prioritize location provider over global provider

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.3.1
 description: A Helm chart for velero
 name: velero
-version: 2.9.10
+version: 2.9.11
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/_helpers.tpl
+++ b/charts/velero/templates/_helpers.tpl
@@ -89,7 +89,7 @@ Create the backup storage location provider
 */}}
 {{- define "velero.backupStorageLocation.provider" -}}
 {{- with .Values.configuration -}}
-{{ default .backupStorageLocation.provider .provider }}
+{{ default .provider .backupStorageLocation.provider }}
 {{- end -}}
 {{- end -}}
 
@@ -107,6 +107,6 @@ Create the volume snapshot location provider
 */}}
 {{- define "velero.volumeSnapshotLocation.provider" -}}
 {{- with .Values.configuration -}}
-{{ default .volumeSnapshotLocation.provider .provider }}
+{{ default .provider .volumeSnapshotLocation.provider }}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Closes https://github.com/vmware-tanzu/helm-charts/issues/95.

Prioritize `configuration.(backupStorageLocation|volumeSnapshotLocation).config` over `configuration.provider`

Signed-off-by: Nikolai Iurin <yurinnick93@gmail.com>