### PR TITLE
Default to the less specific provider

### DIFF
--- a/charts/velero/templates/_helpers.tpl
+++ b/charts/velero/templates/_helpers.tpl
@@ -89,7 +89,7 @@ Create the backup storage location provider
 */}}
 {{- define "velero.backupStorageLocation.provider" -}}
 {{- with .Values.configuration -}}
-{{ default .backupStorageLocation.provider .provider }}
+{{ default .provider .backupStorageLocation.provider }}
 {{- end -}}
 {{- end -}}
 
@@ -107,6 +107,6 @@ Create the volume snapshot location provider
 */}}
 {{- define "velero.volumeSnapshotLocation.provider" -}}
 {{- with .Values.configuration -}}
-{{ default .volumeSnapshotLocation.provider .provider }}
+{{ default .provider .volumeSnapshotLocation.provider }}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
The way the values are written you cannot set different providers and have a deployment. 

To deploy velero for Digital Ocean we need to use `velero/velero-plugin-for-aws:v1.0.1` for the `configuration.backupStorageLocation.provider` and use `digitalocean/velero-plugin:v1.0.0` `configuration.volumeSnapshotLocation.provider`

When you set the `configuration.provider` both these values are ignored. If you omit `configuration.provider` the deployment is ignored see https://github.com/vmware-tanzu/helm-charts/blob/master/charts/velero/templates/deployment.yaml#L1-L2

By defaulting to the more specific it allows the user to set all three values