### PR TITLE
Add support for secret env vars

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.3.1
 description: A Helm chart for velero
 name: velero
-version: 2.9.14
+version: 2.9.15
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -122,6 +122,15 @@ spec:
               value: {{ default "none" $value | quote }}
           {{- end }}
           {{- end }}
+          {{- with .Values.credentials.extraEnvVars }}
+          {{- range $key, $value := . }}
+            - name: {{ default "none" $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "velero.fullname" $ }}
+                  key: {{ default "none" $key }}
+          {{- end }}
+          {{- end }}
 {{- if .Values.initContainers }}
       initContainers:
         {{- toYaml .Values.initContainers | nindent 8 }}

--- a/charts/velero/templates/restic-daemonset.yaml
+++ b/charts/velero/templates/restic-daemonset.yaml
@@ -106,6 +106,21 @@ spec:
               value: /credentials/cloud
             {{- end }}
           {{- end }}
+          {{- with .Values.configuration.extraEnvVars }}
+          {{- range $key, $value := . }}
+            - name: {{ default "none" $key | quote }}
+              value: {{ default "none" $value | quote }}
+          {{- end }}
+          {{- end }}
+          {{- with .Values.credentials.extraEnvVars }}
+          {{- range $key, $value := . }}
+            - name: {{ default "none" $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "velero.fullname" $ }}
+                  key: {{ default "none" $key }}
+          {{- end }}
+          {{- end }}
           securityContext:
             privileged: {{ .Values.restic.privileged }}
             {{- with .Values.restic.securityContext }}

--- a/charts/velero/templates/secret.yaml
+++ b/charts/velero/templates/secret.yaml
@@ -13,4 +13,7 @@ data:
 {{- range $key, $value := .Values.credentials.secretContents }}
   {{ $key }}: {{ $value | b64enc | quote }}
 {{- end }}
+{{- range $key, $value := .Values.credentials.extraEnvVars }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+{{- end }}
 {{- end -}}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -187,6 +187,8 @@ credentials:
   # true and `existingSecret` is empty. This should be the contents
   # of your IAM credentials file.
   secretContents: {}
+  # additional key/value pairs to be used as environment variables such as "DIGITALOCEAN_TOKEN: <your-key>". Values will be stored in the secret.
+  extraEnvVars: {}
 
 # Whether to create backupstoragelocation crd, if false => do not create a default backup location
 backupsEnabled: true


### PR DESCRIPTION
This PR adds a new value `credentials.extraEnvVars` allowing to store data in a secret and expose it to the container through an environment variable.
This is necessary for the [Digital Ocean plugin](https://github.com/digitalocean/velero-plugin) and maybe other.

I tested it (and it works). This PR also includes #94 (because without this PR, the chart is broken). I'll rebase when #94 will be merged.

Thanks for this great tool by the way!