### PR TITLE
fix: Restic daemonset SA always set, like velero deployment

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.4.0
 description: A Helm chart for velero
 name: velero
-version: 2.12.10
+version: 2.12.11
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/restic-daemonset.yaml
+++ b/charts/velero/templates/restic-daemonset.yaml
@@ -26,9 +26,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      {{- if .Values.serviceAccount.server.create }}
       serviceAccountName: {{ include "velero.serverServiceAccount" . }}
-      {{- end }}
       securityContext:
         runAsUser: 0
       {{- if .Values.restic.priorityClassName }}


### PR DESCRIPTION
Signed-off-by: Kenny Younger <kyounger@gmail.com>

I don't think there is a reason that the SA should be gated. Existing service accounts should be supported.

Fixes #118 