### PR TITLE
helm 2,3 CI test + Upgrade CRDs to v1.4

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -14,18 +14,41 @@ jobs:
 
       - name: Run chart-testing (lint)
         id: lint
-        uses: helm/chart-testing-action@v1.0.0-rc.1
+        uses: helm/chart-testing-action@v1.0.0-rc.2
         with:
           command: lint
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0-alpha.3
-        with:
-          installLocalPathProvisioner: true
+        uses: helm/kind-action@v1.0.0-rc.1
         # Only build a kind cluster if there are chart changes to test.
         if: steps.lint.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v1.0.0-rc.1
+        uses: helm/chart-testing-action@v1.0.0-rc.2
+        with:
+          command: install
+
+  helm2-lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Run chart-testing (lint)
+        id: lint
+        uses: helm/chart-testing-action@v1.0.0-alpha.3 # fixed on v1.0.0-alpha.3 for helm2
+        with:
+          command: lint
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.0.0-rc.1
+        # Only build a kind cluster if there are chart changes to test.
+        if: steps.lint.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        uses: helm/chart-testing-action@v1.0.0-alpha.3 # fixed on v1.0.0-alpha.3 for helm2
         with:
           command: install

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.4.0
 description: A Helm chart for velero
 name: velero
-version: 2.12.1
+version: 2.12.2
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/crds/backups.yaml
+++ b/charts/velero/crds/backups.yaml
@@ -1,12 +1,16 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: backups.velero.io
   labels:
     app.kubernetes.io/name: velero
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: backups.velero.io
 spec:
   group: velero.io
   names:
@@ -340,6 +344,10 @@ spec:
               format: date-time
               nullable: true
               type: string
+            formatVersion:
+              description: FormatVersion is the backup format version, including major,
+                minor, and patch version.
+              type: string
             phase:
               description: Phase is the current state of the Backup.
               enum:
@@ -351,6 +359,24 @@ spec:
               - Failed
               - Deleting
               type: string
+            progress:
+              description: Progress contains information about the backup's execution
+                progress. Note that this information is best-effort only -- if Velero
+                fails to update it during a backup for any reason, it may be inaccurate/stale.
+              nullable: true
+              properties:
+                itemsBackedUp:
+                  description: ItemsBackedUp is the number of items that have actually
+                    been written to the backup tarball so far.
+                  type: integer
+                totalItems:
+                  description: TotalItems is the total number of items to be backed
+                    up. This number may change throughout the execution of the backup
+                    due to plugins that return additional related items to back up,
+                    the velero.io/exclude-from-backup label, and various other filters
+                    that happen as items are processed.
+                  type: integer
+              type: object
             startTimestamp:
               description: StartTimestamp records the time a backup was started. Separate
                 from CreationTimestamp, since that value changes on restores. The
@@ -366,7 +392,8 @@ spec:
               nullable: true
               type: array
             version:
-              description: Version is the backup format version.
+              description: 'Version is the backup format major version. Deprecated:
+                Please see FormatVersion'
               type: integer
             volumeSnapshotsAttempted:
               description: VolumeSnapshotsAttempted is the total number of attempted
@@ -388,3 +415,9 @@ spec:
   - name: v1
     served: true
     storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/velero/crds/backupstoragelocations.yaml
+++ b/charts/velero/crds/backupstoragelocations.yaml
@@ -1,12 +1,16 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: backupstoragelocations.velero.io
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: backupstoragelocations.velero.io
 spec:
   group: velero.io
   names:
@@ -61,6 +65,11 @@ spec:
                 bucket:
                   description: Bucket is the bucket to use for object storage.
                   type: string
+                caCert:
+                  description: CACert defines a CA bundle to use when verifying TLS
+                    connections to the provider.
+                  format: byte
+                  type: string
                 prefix:
                   description: Prefix is the path inside a bucket to use for Velero
                     storage. Optional.
@@ -113,3 +122,9 @@ spec:
   - name: v1
     served: true
     storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/velero/crds/deletebackuprequests.yaml
+++ b/charts/velero/crds/deletebackuprequests.yaml
@@ -1,12 +1,16 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: deletebackuprequests.velero.io
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: deletebackuprequests.velero.io
 spec:
   group: velero.io
   names:
@@ -65,3 +69,9 @@ spec:
   - name: v1
     served: true
     storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/velero/crds/downloadrequests.yaml
+++ b/charts/velero/crds/downloadrequests.yaml
@@ -1,12 +1,16 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: downloadrequests.velero.io
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: downloadrequests.velero.io
 spec:
   group: velero.io
   names:
@@ -86,3 +90,9 @@ spec:
   - name: v1
     served: true
     storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/velero/crds/podvolumebackups.yaml
+++ b/charts/velero/crds/podvolumebackups.yaml
@@ -1,12 +1,16 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: podvolumebackups.velero.io
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: podvolumebackups.velero.io
 spec:
   group: velero.io
   names:
@@ -154,3 +158,9 @@ spec:
   - name: v1
     served: true
     storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/velero/crds/podvolumerestores.yaml
+++ b/charts/velero/crds/podvolumerestores.yaml
@@ -1,12 +1,16 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: podvolumerestores.velero.io
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: podvolumerestores.velero.io
 spec:
   group: velero.io
   names:
@@ -137,3 +141,9 @@ spec:
   - name: v1
     served: true
     storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/velero/crds/resticrepositories.yaml
+++ b/charts/velero/crds/resticrepositories.yaml
@@ -1,12 +1,16 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: resticrepositories.velero.io
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: resticrepositories.velero.io
 spec:
   group: velero.io
   names:
@@ -81,3 +85,9 @@ spec:
   - name: v1
     served: true
     storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/velero/crds/restores.yaml
+++ b/charts/velero/crds/restores.yaml
@@ -1,12 +1,16 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: restores.velero.io
   labels:
     app.kubernetes.io/name: velero
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: restores.velero.io
 spec:
   group: velero.io
   names:
@@ -181,3 +185,9 @@ spec:
   - name: v1
     served: true
     storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/velero/crds/schedules.yaml
+++ b/charts/velero/crds/schedules.yaml
@@ -1,12 +1,16 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: schedules.velero.io
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: schedules.velero.io
 spec:
   group: velero.io
   names:
@@ -367,3 +371,9 @@ spec:
   - name: v1
     served: true
     storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/velero/crds/serverstatusrequests.yaml
+++ b/charts/velero/crds/serverstatusrequests.yaml
@@ -1,12 +1,16 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: serverstatusrequests.velero.io
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: serverstatusrequests.velero.io
 spec:
   group: velero.io
   names:
@@ -77,3 +81,9 @@ spec:
   - name: v1
     served: true
     storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/velero/crds/volumesnapshotlocations.yaml
+++ b/charts/velero/crds/volumesnapshotlocations.yaml
@@ -1,12 +1,16 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: volumesnapshotlocations.velero.io
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: volumesnapshotlocations.velero.io
 spec:
   group: velero.io
   names:
@@ -66,3 +70,9 @@ spec:
   - name: v1
     served: true
     storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -64,6 +64,9 @@ metrics:
     enabled: false
     additionalLabels: {}
 
+# Install CRDs as a templates. Enabled by default.
+installCRDs: true
+
 ##
 ## End of deployment-related settings.
 ##

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -64,9 +64,6 @@ metrics:
     enabled: false
     additionalLabels: {}
 
-# Install CRDs as a templates. Enabled by default.
-installCRDs: true
-
 ##
 ## End of deployment-related settings.
 ##

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,7 +1,5 @@
 # See https://github.com/helm/chart-testing#configuration
-remote: origin
 chart-dirs:
   - charts
-chart-repos:
-  - incubator=https://kubernetes-charts-incubator.storage.googleapis.com
-helm-extra-args: --timeout=500s
+remote: origin
+target-branch: main

--- a/ct.yaml
+++ b/ct.yaml
@@ -3,3 +3,4 @@ chart-dirs:
   - charts
 remote: origin
 target-branch: main
+upgrade: true


### PR DESCRIPTION
1. change target branch from master to main
2. add helm2 & helm3 CI test
3. bump the CRDs manifests sync with velero `v1.4.0`

then #104 is no more needed.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>