### PR TITLE
Fix Helm 2 CRD generation

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.4.0
 description: A Helm chart for velero
 name: velero
-version: 2.12.2
+version: 2.12.3
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.4.0
 description: A Helm chart for velero
 name: velero
-version: 2.12.1
+version: 2.12.2
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/crds/backups.yaml
+++ b/charts/velero/crds/backups.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/charts/velero/crds/backupstoragelocations.yaml
+++ b/charts/velero/crds/backupstoragelocations.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/charts/velero/crds/deletebackuprequests.yaml
+++ b/charts/velero/crds/deletebackuprequests.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/charts/velero/crds/downloadrequests.yaml
+++ b/charts/velero/crds/downloadrequests.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/charts/velero/crds/podvolumebackups.yaml
+++ b/charts/velero/crds/podvolumebackups.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/charts/velero/crds/podvolumerestores.yaml
+++ b/charts/velero/crds/podvolumerestores.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/charts/velero/crds/resticrepositories.yaml
+++ b/charts/velero/crds/resticrepositories.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/charts/velero/crds/restores.yaml
+++ b/charts/velero/crds/restores.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/charts/velero/crds/schedules.yaml
+++ b/charts/velero/crds/schedules.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/charts/velero/crds/serverstatusrequests.yaml
+++ b/charts/velero/crds/serverstatusrequests.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/charts/velero/crds/volumesnapshotlocations.yaml
+++ b/charts/velero/crds/volumesnapshotlocations.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/charts/velero/templates/crds.yaml
+++ b/charts/velero/templates/crds.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.installCRDs (eq .Release.Service "Tiller") }}
 {{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
-  {{ $.Files.Get $path }}
+{{ $.Files.Get $path }}
 ---
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Arthur Outhenin-Chalandre <arthur@cri.epita.fr>

I have this issue when I install the latest velero helm chart with ArgoCD:
```
rpc error: code = Unknown desc = Failed to unmarshal manifest: error unmarshaling JSON: Object 'Kind' is missing in '{"apiVersion":"apiextensions.k8s.io/v1beta1"}'
```

ArgoCD recognizes the velero chart as an helm2 chart and therefore uses the helm2 binary for it.
I tested and I saw that the line `apiVersion: apiextensions.k8s.io/v1beta1` is not indented correctly with helm2 (the output in helm3 is correct). This PR is fixing this indentation issue.