### PR TITLE
fix: helm upgrade did not work correctly on BSL and VSL configuration

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.4.0
 description: A Helm chart for velero
 name: velero
-version: 2.12.6
+version: 2.12.7
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/README.md
+++ b/charts/velero/README.md
@@ -144,6 +144,14 @@ The [instructions found here](https://velero.io/docs/v1.1.0/upgrade-to-1.1/) wil
 
 Note: when you uninstall the Velero server, all backups remain untouched.
 
+### Using Helm 2
+
 ```bash
 helm delete <RELEASE NAME> --purge
+```
+
+#### Using Helm 3
+
+```bash
+helm delete <RELEASE NAME> -n <YOUR NAMESPACE>
 ```

--- a/charts/velero/README.md
+++ b/charts/velero/README.md
@@ -59,7 +59,7 @@ helm install vmware-tanzu/velero --namespace <YOUR NAMESPACE> \
 Add/update the necessary values by changing the values.yaml from this repository, then run:
 
 ```bash
-helm install vmware-tanzu/velero --namespace <YOUR NAMESPACE>  -f values.yaml --generate-name
+helm install vmware-tanzu/velero --namespace <YOUR NAMESPACE> -f values.yaml --generate-name
 ```
 ##### Upgrade the configuration
 
@@ -110,7 +110,7 @@ helm install vmware-tanzu/velero --namespace <YOUR NAMESPACE> \
 Add/update the necessary values by changing the values.yaml from this repository, then run:
 
 ```bash
-helm install vmware-tanzu/velero --namespace <YOUR NAMESPACE>  -f values.yaml
+helm install vmware-tanzu/velero --namespace <YOUR NAMESPACE> -f values.yaml
 ```
 
 ##### Upgrade the configuration

--- a/charts/velero/crds/backups.yaml
+++ b/charts/velero/crds/backups.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: velero
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null

--- a/charts/velero/crds/backupstoragelocations.yaml
+++ b/charts/velero/crds/backupstoragelocations.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null

--- a/charts/velero/crds/deletebackuprequests.yaml
+++ b/charts/velero/crds/deletebackuprequests.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null

--- a/charts/velero/crds/downloadrequests.yaml
+++ b/charts/velero/crds/downloadrequests.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null

--- a/charts/velero/crds/podvolumebackups.yaml
+++ b/charts/velero/crds/podvolumebackups.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null

--- a/charts/velero/crds/podvolumerestores.yaml
+++ b/charts/velero/crds/podvolumerestores.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null

--- a/charts/velero/crds/resticrepositories.yaml
+++ b/charts/velero/crds/resticrepositories.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null

--- a/charts/velero/crds/restores.yaml
+++ b/charts/velero/crds/restores.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: velero
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null

--- a/charts/velero/crds/schedules.yaml
+++ b/charts/velero/crds/schedules.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,post-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null

--- a/charts/velero/crds/serverstatusrequests.yaml
+++ b/charts/velero/crds/serverstatusrequests.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null

--- a/charts/velero/crds/volumesnapshotlocations.yaml
+++ b/charts/velero/crds/volumesnapshotlocations.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null

--- a/charts/velero/templates/backupstoragelocation.yaml
+++ b/charts/velero/templates/backupstoragelocation.yaml
@@ -4,7 +4,7 @@ kind: BackupStorageLocation
 metadata:
   name: {{ include "velero.backupStorageLocation.name" . }}
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}

--- a/charts/velero/templates/volumesnapshotlocation.yaml
+++ b/charts/velero/templates/volumesnapshotlocation.yaml
@@ -4,7 +4,7 @@ kind: VolumeSnapshotLocation
 metadata:
   name: {{ include "velero.volumeSnapshotLocation.name" . }}
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}


### PR DESCRIPTION
Fix helm upgrade did not work correctly on BSL and VSL configuration.

```
# Install helm chart previous version 2.12.0
helm2 install \
--name velero \
--namespace velero \
--set-file credentials.secretContents.cloud=credentials-velero \
--set configuration.provider=aws \
--set configuration.backupStorageLocation.name=default \
--set configuration.backupStorageLocation.bucket=velero \
--set configuration.backupStorageLocation.config.region=minio \
--set configuration.backupStorageLocation.config.s3ForcePathStyle=true \
--set configuration.backupStorageLocation.config.s3Url=http://minio.velero.svc.cluster.local:9000 \
--set initContainers[0].name=velero-plugin-for-aws \
--set initContainers[0].image=velero/velero-plugin-for-aws:v1.1.0 \
--set initContainers[0].volumeMounts[0].mountPath=/target \
--set initContainers[0].volumeMounts[0].name=plugins \
--version=2.12.0 \
vmware-tanzu/velero

# Get BSL
velero backup-location get

# Upgrade to version 2.12.6
helm2 upgrade velero --reuse-values vmware-tanzu/velero

# Get BSL
velero backup-location get
```

ref to #109 