### PR TITLE
Add Github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Tell us about a problem you are experiencing
+
+---
+
+**What steps did you take and what happened:**
+[A clear and concise description of what the bug is, and what commands you ran.)
+
+
+**What did you expect to happen:**
+
+
+**The output of the following commands will help us better understand what's going on**:
+(Pasting long output into a [GitHub gist](https://gist.github.com) or other pastebin is fine.)
+
+
+**Anything else you would like to add:**
+[Miscellaneous information that will assist in solving the issue.]
+
+
+**Environment:**
+
+- helm version (use `helm version`): 
+- helm chart version and app version:
+  - helm2 (use `helm list`):
+  - helm3 (use `helm list -n <YOUR NAMESPACE>`):
+- Kubernetes version (use `kubectl version`):
+- Kubernetes installer & version:
+- Cloud provider or hardware configuration:
+- OS (e.g. from `/etc/os-release`):

--- a/.github/ISSUE_TEMPLATE/feature-enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-enhancement-request.md
@@ -1,0 +1,28 @@
+---
+name: Feature enhancement request
+about: Suggest an idea for this project
+
+---
+
+**Describe the problem/challenge you have**
+[A description of the current limitation/problem/challenge that you are experiencing.]
+
+
+**Describe the solution you'd like**
+[A clear and concise description of what you want to happen.]
+
+
+**Anything else you would like to add:**
+[Miscellaneous information that will assist in solving the issue.]
+
+
+**Environment:**
+
+- helm version (use `helm version`): 
+- helm chart version and app version:
+  - helm2 (use `helm list`):
+  - helm3 (use `helm list -n <YOUR NAMESPACE>`):
+- Kubernetes version (use `kubectl version`):
+- Kubernetes installer & version:
+- Cloud provider or hardware configuration:
+- OS (e.g. from `/etc/os-release`):


### PR DESCRIPTION
Provides the Github issue templates to helps us easier to trace the issue with helm chart version and app version, also the installation commands.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>