### PR TITLE
[velero] bump velero version to v1.4.2

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 1.4.0
+appVersion: 1.4.2
 description: A Helm chart for velero
 name: velero
-version: 2.12.14
+version: 2.12.15
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/README.md
+++ b/charts/velero/README.md
@@ -12,7 +12,7 @@ See the different options for installing the [Velero CLI](https://velero.io/docs
 
 ### Velero version
 
-This helm chart installs Velero version v1.4.0 https://github.com/vmware-tanzu/velero/tree/v1.4.0. See the [#Upgrading](#upgrading) section for information on how to upgrade from other versions.
+This helm chart installs Velero version v1.4.2 https://github.com/vmware-tanzu/velero/tree/v1.4.2. See the [#Upgrading](#upgrading) section for information on how to upgrade from other versions.
 
 ### Provider credentials
 
@@ -45,7 +45,7 @@ helm install vmware-tanzu/velero --namespace <YOUR NAMESPACE> \
 --set configuration.volumeSnapshotLocation.name=<VOLUME SNAPSHOT LOCATION NAME> \
 --set configuration.volumeSnapshotLocation.config.region=<REGION> \
 --set image.repository=velero/velero \
---set image.tag=v1.4.0 \
+--set image.tag=v1.4.2 \
 --set image.pullPolicy=IfNotPresent \
 --set initContainers[0].name=velero-plugin-for-aws \
 --set initContainers[0].image=velero/velero-plugin-for-aws:v1.1.0 \
@@ -97,7 +97,7 @@ helm install vmware-tanzu/velero --namespace <YOUR NAMESPACE> \
 --set configuration.volumeSnapshotLocation.name=<VOLUME SNAPSHOT LOCATION NAME> \
 --set configuration.volumeSnapshotLocation.config.region=<REGION> \
 --set image.repository=velero/velero \
---set image.tag=v1.4.0 \
+--set image.tag=v1.4.2 \
 --set image.pullPolicy=IfNotPresent \
 --set initContainers[0].name=velero-plugin-for-aws \
 --set initContainers[0].image=velero/velero-plugin-for-aws:v1.1.0 \
@@ -123,9 +123,9 @@ helm upgrade vmware-tanzu/velero <RELEASE NAME> --reuse-values --set configurati
 
 ## Upgrading
 
-### Upgrading to v1.4.0
+### Upgrading to v1.4
 
-The [instructions found here](https://velero.io/docs/v1.4/upgrade-to-1.4/) will assist you in upgrading from version v1.3.x to v1.4.0.
+The [instructions found here](https://velero.io/docs/v1.4/upgrade-to-1.4/) will assist you in upgrading from version v1.3.x to v1.4.
 
 
 ### Upgrading to v1.3.1
@@ -150,7 +150,7 @@ Note: when you uninstall the Velero server, all backups remain untouched.
 helm delete <RELEASE NAME> --purge
 ```
 
-#### Using Helm 3
+### Using Helm 3
 
 ```bash
 helm delete <RELEASE NAME> -n <YOUR NAMESPACE>

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -6,7 +6,7 @@
 # enabling restic). Required.
 image:
   repository: velero/velero
-  tag: v1.4.0
+  tag: v1.4.2
   # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38. If used, it will
   # take precedence over the image.tag.
   # digest:


### PR DESCRIPTION
#### Special notes for your reviewer:

I did not see the CRD changed [from v1.4.0 to v1.4.2](https://github.com/vmware-tanzu/velero/compare/v1.4.0...v1.4.2).
So, we don't need to update the CRDs.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
