### PR TITLE
[velero] Add the default-volumes-to-restic flag for opt-out Restic pod volume backup support.

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.4.2
 description: A Helm chart for velero
 name: velero
-version: 2.12.15
+version: 2.12.16
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -65,6 +65,9 @@ spec:
             {{- with .resticTimeout }}
             - --restic-timeout={{ . }}
             {{- end }}
+            {{- with .defaultVolumesToRestic}}
+            - --default-volumes-to-restic={{ . }}
+            {{- end }}
             {{- if .restoreOnlyMode }}
             - --restore-only
             {{- end }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -141,6 +141,8 @@ configuration:
   backupSyncPeriod:
   # `velero server` default: 1h
   resticTimeout:
+  # `velero server` default: false
+  defaultVolumesToRestic: false
   # `velero server` default: namespaces,persistentvolumes,persistentvolumeclaims,secrets,configmaps,serviceaccounts,limitranges,pods
   restoreResourcePriorities:
   # `velero server` default: false


### PR DESCRIPTION
Signed-off-by: Piper Dougherty <doughertypiper@gmail.com>

#### Special notes for your reviewer:
- Added as one of the new features to come with Velero 1.5.

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[velero]`)
