### PR TITLE
[velero] Fix helm 3.3.0 lint issue

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.4.2
 description: A Helm chart for velero
 name: velero
-version: 2.12.15
+version: 2.12.16
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/cleanup-crd.yaml
+++ b/charts/velero/templates/cleanup-crd.yaml
@@ -1,6 +1,6 @@
+{{- if and .Values.installCRDs .Values.cleanUpCRDs  }}
 # This job is meant primarily for cleaning up on CI systems.
 # Using this on production systems, especially those that have multiple releases of Velero, will be destructive.
-{{- if and .Values.installCRDs .Values.cleanUpCRDs  }}
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
Consider to wrap comment inside to fix error raised by helm 3.3.0:

**Before**
```
velero ➤ helm version                                                                                                                                           git:pr/181
version.BuildInfo{Version:"v3.3.0", GitCommit:"8a4aeec08d67a7b84472007529e8097ec3742105", GitTreeState:"dirty", GoVersion:"go1.14.7"}
velero ➤ helm lint                                                                                                                                              git:pr/181
==> Linting .
[ERROR] templates/cleanup-crd.yaml: object name does not conform to Kubernetes naming requirements: ""

Error: 1 chart(s) linted, 1 chart(s) failed
```
**After**
```
velero ➤ helm version                                                                                                                                           git:pr/181
version.BuildInfo{Version:"v3.3.0", GitCommit:"8a4aeec08d67a7b84472007529e8097ec3742105", GitTreeState:"dirty", GoVersion:"go1.14.7"}
velero ➤ helm lint                                                                                                                                             git:pr/181*
==> Linting .

1 chart(s) linted, 0 chart(s) failed
```

#### Special notes for your reviewer:
`none`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[velero]`)