### PR TITLE
[velero] Add enable/disable option for helm hooks

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 1.5.1
+appVersion: 1.5.2
 description: A Helm chart for velero
 name: velero
-version: 2.13.4
+version: 2.13.7
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.5.1
 description: A Helm chart for velero
 name: velero
-version: 2.13.3
+version: 2.13.4
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/crds/backups.yaml
+++ b/charts/velero/crds/backups.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: velero
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.3.0
   name: backups.velero.io
 spec:

--- a/charts/velero/crds/backupstoragelocations.yaml
+++ b/charts/velero/crds/backupstoragelocations.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.3.0
   name: backupstoragelocations.velero.io
 spec:

--- a/charts/velero/crds/deletebackuprequests.yaml
+++ b/charts/velero/crds/deletebackuprequests.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.3.0
   name: deletebackuprequests.velero.io
 spec:

--- a/charts/velero/crds/downloadrequests.yaml
+++ b/charts/velero/crds/downloadrequests.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.3.0
   name: downloadrequests.velero.io
 spec:

--- a/charts/velero/crds/podvolumebackups.yaml
+++ b/charts/velero/crds/podvolumebackups.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.3.0
   name: podvolumebackups.velero.io
 spec:

--- a/charts/velero/crds/podvolumerestores.yaml
+++ b/charts/velero/crds/podvolumerestores.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.3.0
   name: podvolumerestores.velero.io
 spec:

--- a/charts/velero/crds/resticrepositories.yaml
+++ b/charts/velero/crds/resticrepositories.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.3.0
   name: resticrepositories.velero.io
 spec:

--- a/charts/velero/crds/restores.yaml
+++ b/charts/velero/crds/restores.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: velero
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.3.0
   name: restores.velero.io
 spec:

--- a/charts/velero/crds/schedules.yaml
+++ b/charts/velero/crds/schedules.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install,post-upgrade
-    "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.3.0
   name: schedules.velero.io
 spec:

--- a/charts/velero/crds/serverstatusrequests.yaml
+++ b/charts/velero/crds/serverstatusrequests.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.3.0
   name: serverstatusrequests.velero.io
 spec:

--- a/charts/velero/crds/volumesnapshotlocations.yaml
+++ b/charts/velero/crds/volumesnapshotlocations.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.3.0
   name: volumesnapshotlocations.velero.io
 spec:

--- a/charts/velero/templates/_helpers.tpl
+++ b/charts/velero/templates/_helpers.tpl
@@ -110,3 +110,11 @@ Create the volume snapshot location provider
 {{ default .provider .volumeSnapshotLocation.provider }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Helm hooks for Helm v2 CRDs 
+*/}}
+{{- define "velero.helmhooks.crds" -}}
+{{ print "\"helm.sh/hook\": pre-install,pre-upgrade" | indent 4 }}
+{{ print "\"helm.sh/hook-delete-policy\": \"before-hook-creation\"" | indent 4 }}
+{{- end -}}

--- a/charts/velero/templates/backupstoragelocation.yaml
+++ b/charts/velero/templates/backupstoragelocation.yaml
@@ -4,7 +4,7 @@ kind: BackupStorageLocation
 metadata:
   name: {{ include "velero.backupStorageLocation.name" . }}
   annotations:
-  {{- if .Values.enableHelmHooks.templates }}
+  {{- if .Values.enableHelmHooks }}
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
   {{- end }}

--- a/charts/velero/templates/backupstoragelocation.yaml
+++ b/charts/velero/templates/backupstoragelocation.yaml
@@ -4,8 +4,10 @@ kind: BackupStorageLocation
 metadata:
   name: {{ include "velero.backupStorageLocation.name" . }}
   annotations:
+  {{- if .Values.enableHelmHooks.templates }}
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/velero/templates/crds.yaml
+++ b/charts/velero/templates/crds.yaml
@@ -1,10 +1,13 @@
 {{- if and .Values.installCRDs (eq .Release.Service "Tiller") }}
 {{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
-{{- if $.Values.enableHelmHooks }}
+{{- if not $.Values.enableHelmHooks }}
 {{ $.Files.Get $path }}
 {{- else }}
 {{- range $.Files.Lines $path }}
-{{- if not ( contains "helm.sh/hook" . ) }}
+{{- if contains "annotations:" . }}
+{{ . }}
+{{ template "velero.helmhooks.crds" . }}
+{{- else }}
 {{ . }}
 {{- end }}
 {{- end }}

--- a/charts/velero/templates/crds.yaml
+++ b/charts/velero/templates/crds.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.installCRDs (eq .Release.Service "Tiller") }}
 {{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
 {{- if $.Values.enableHelmHooks.crds }}
-{{- $.Files.Get $path }}
+{{ $.Files.Get $path }}
 {{- else }}
 {{- range $.Files.Lines $path }}
 {{- if not ( contains "helm.sh/hook" . ) }}

--- a/charts/velero/templates/crds.yaml
+++ b/charts/velero/templates/crds.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.installCRDs (eq .Release.Service "Tiller") }}
 {{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
-{{- if $.Values.enableHelmHooks.crds }}
+{{- if $.Values.enableHelmHooks }}
 {{ $.Files.Get $path }}
 {{- else }}
 {{- range $.Files.Lines $path }}

--- a/charts/velero/templates/crds.yaml
+++ b/charts/velero/templates/crds.yaml
@@ -1,6 +1,14 @@
 {{- if and .Values.installCRDs (eq .Release.Service "Tiller") }}
 {{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
-{{ $.Files.Get $path }}
+{{- if $.Values.enableHelmHooks.crds }}
+{{- $.Files.Get $path }}
+{{- else }}
+{{- range $.Files.Lines $path }}
+{{- if not ( contains "helm.sh/hook" . ) }}
+{{ . }}
+{{- end }}
+{{- end }}
+{{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/charts/velero/templates/schedule.yaml
+++ b/charts/velero/templates/schedule.yaml
@@ -4,7 +4,7 @@ kind: Schedule
 metadata:
   name: {{ include "velero.fullname" $ }}-{{ $scheduleName }}
   annotations:
-  {{- if $.Values.enableHelmHooks.templates }}
+  {{- if $.Values.enableHelmHooks }}
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
   {{- end }}

--- a/charts/velero/templates/schedule.yaml
+++ b/charts/velero/templates/schedule.yaml
@@ -4,8 +4,10 @@ kind: Schedule
 metadata:
   name: {{ include "velero.fullname" $ }}-{{ $scheduleName }}
   annotations:
+  {{- if $.Values.enableHelmHooks.templates }}
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}

--- a/charts/velero/templates/volumesnapshotlocation.yaml
+++ b/charts/velero/templates/volumesnapshotlocation.yaml
@@ -4,8 +4,10 @@ kind: VolumeSnapshotLocation
 metadata:
   name: {{ include "velero.volumeSnapshotLocation.name" . }}
   annotations:
+  {{- if .Values.enableHelmHooks.templates }}
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/velero/templates/volumesnapshotlocation.yaml
+++ b/charts/velero/templates/volumesnapshotlocation.yaml
@@ -4,7 +4,7 @@ kind: VolumeSnapshotLocation
 metadata:
   name: {{ include "velero.volumeSnapshotLocation.name" . }}
   annotations:
-  {{- if .Values.enableHelmHooks.templates }}
+  {{- if .Values.enableHelmHooks }}
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
   {{- end }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -72,8 +72,9 @@ metrics:
 # Install CRDs as a templates. Enabled by default.
 installCRDs: true
 
-# Enable/disable helm hooks annotations for CRDs (Helm v2) and templates
-# You should disable this if using a deploy tool that doesn't support helm hooks
+# Enable/disable all helm hooks annotations
+# You should disable this if using a deploy tool that doesn't support helm hooks,
+# such as ArgoCD
 enableHelmHooks: true
 
 ##

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -72,11 +72,9 @@ metrics:
 # Install CRDs as a templates. Enabled by default.
 installCRDs: true
 
-# Enable/disable helm hooks annotations for Helm v2 in CRDs and/or templates
+# Enable/disable helm hooks annotations for CRDs (Helm v2) and templates
 # You should disable this if using a deploy tool that doesn't support helm hooks
-enableHelmHooks:
-  crds: true
-  templates: true
+enableHelmHooks: true
 
 ##
 ## End of deployment-related settings.

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -72,6 +72,12 @@ metrics:
 # Install CRDs as a templates. Enabled by default.
 installCRDs: true
 
+# Enable/disable helm hooks annotations for Helm v2 in CRDs and/or templates
+# You should disable this if using a deploy tool that doesn't support helm hooks
+enableHelmHooks:
+  crds: true
+  templates: true
+
 ##
 ## End of deployment-related settings.
 ##


### PR DESCRIPTION
#### Special notes for your reviewer:

Create an option in values to disable helm hooks used in CRDs (for Helm v2) and templates manifest (like BackupStorageLocation), introduced in #109 and #153. 

With this change it's possible to install this chart using ArgoCD without any problems, setting the new option to false:

```
enableHelmHooks: false
```

It's possible to disable only CRD hooks or template hooks, in case you don't want to disable both.

The default option is true, which enables all helm hooks.

Helm hooks in crds folder, for Helm v3, are untouched, because they can't be templated.

Fix #158 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
