### PR TITLE
[velero] Restrict release on upstream repo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   release:
+    if: github.repository == 'vmware-tanzu/helm-charts'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
#### Special notes for your reviewer:

Restrict to run release on upstream repo only, to fixes when developer forks repo `vmware-tanze/helm-charts` that would fail on running CI at the main branch.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
