### PR TITLE
[velero] creds env from secret

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.5.2
 description: A Helm chart for velero
 name: velero
-version: 2.13.6
+version: 2.13.7
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.5.2
 description: A Helm chart for velero
 name: velero
-version: 2.13.7
+version: 2.13.8
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -106,6 +106,11 @@ spec:
             {{- if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
+        {{- if .Values.credentials.extraSecretRef }}
+          envFrom:
+          - secretRef:
+              name: {{ .Values.credentials.extraSecretRef }}
+        {{- end }}
           env:
             - name: VELERO_SCRATCH_DIR
               value: /scratch

--- a/charts/velero/templates/restic-daemonset.yaml
+++ b/charts/velero/templates/restic-daemonset.yaml
@@ -92,6 +92,11 @@ spec:
             {{- if .Values.restic.extraVolumeMounts }}
             {{- toYaml .Values.restic.extraVolumeMounts | nindent 12 }}
             {{- end }}
+        {{- if .Values.credentials.extraSecretRef }}
+          envFrom:
+          - secretRef:
+              name: {{ .Values.credentials.extraSecretRef }}
+        {{- end }}
           env:
             - name: VELERO_NAMESPACE
               valueFrom:

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -206,6 +206,10 @@ credentials:
   secretContents: {}
   # additional key/value pairs to be used as environment variables such as "DIGITALOCEAN_TOKEN: <your-key>". Values will be stored in the secret.
   extraEnvVars: {}
+  # Name of a pre-existing secret (if any) in the Velero namespace
+  # that will be used to load environment variables into velero and restic.
+  # Secret should be in format - https://kubernetes.io/docs/concepts/configuration/secret/#use-case-as-container-environment-variables
+  extraSecretRef: ""
 
 # Whether to create backupstoragelocation crd, if false => do not create a default backup location
 backupsEnabled: true


### PR DESCRIPTION
#### Description

This PR enables creation of velero deployment with environment variables configured from secret by using `envFrom.secretRef`. This way of configuration is more secure than configuring environment variables directly with `env` (in case of this repository `credentials.extraEnvVars`).

This was done in order to enable users to securely configure environment variables for clouds such as Openstack, where authentication is most of the time configured differently (env vars) compared to clouds such as AWS, GCP, where secret is mounted from volume.

Example usage:

1. Create secret in velero namespace:

```yaml
---
apiVersion: v1
kind: Secret
metadata:
  name: openstack-credentials
  namespace: velero
type: Opaque
data:
  OS_PROJECT_DOMAIN_NAME: <base64_encoded_value>
  OS_USER_DOMAIN_NAME: <base64_encoded_value>
  OS_DOMAIN_NAME: <base64_encoded_value>
  OS_PROJECT_ID: <base64_encoded_value>
  OS_USERNAME: <base64_encoded_value>
  OS_PASSWORD: <base64_encoded_value>
  OS_AUTH_URL: <base64_encoded_value>
  OS_IDENTITY_API_VERSION: <base64_encoded_value>
  OS_IMAGE_API_VERSION: <base64_encoded_value>
```

2. Specify secret ref to previously created secret in helm chart values:

```yaml
---
...
...
credentials:
  extraSecretRef: "openstack-credentials"
...
...
```

Output of `kubectl describe deployment velero`:

```yaml
Pod Template:
  Containers:
   velero:
    Environment Variables from:
      openstack-credentials  Secret  Optional: false
```


#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the ~~README.md~~ `values.yaml`
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
