### PR TITLE
[velero] Fix actions/checkout@v2 does not fetches full git history

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"


### PR DESCRIPTION
#### Special notes for your reviewer:

See https://github.com/helm/chart-releaser-action/issues/13#issuecomment-602063896
The `actions/checkout@v2` by default only fetch HEAD git history, this causes the helm/chart-releaser-action can't fetch the full git history.

fixes #20 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
