### PR TITLE
Velero: Minor bugfix in backupstoragelocation.yaml

### DIFF
--- a/charts/velero/templates/backupstoragelocation.yaml
+++ b/charts/velero/templates/backupstoragelocation.yaml
@@ -24,11 +24,12 @@ spec:
     {{- with .caCert }}
     caCert: {{ . }}
     {{- end }}
-{{- with .config }}
   config:
-{{ toYaml . | indent 4}}
-{{- if .s3ForcePathStyle }}
-    s3ForcePathStyle: {{ .s3ForcePathStyle | quote }}
+{{- range $key, $value := .config }}
+{{- if (eq $key "s3ForcePathStyle") }}
+    {{ $key }}: {{ $value | quote }}
+{{- else }}
+    {{ $key }}: {{ $value }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
(.Values.configuration.backupStorageLocation.config contains .s3ForcePathStyle parameter)

As per the old configuration of backupstoragelocation.yaml, 

{{- with .config }}
  config:
{{ toYaml . | indent 4}}

already populates .s3ForcePathStyle (if mentioned in values.yaml file) with boolean value.

But then again, 
{{- if .s3ForcePathStyle }}
    s3ForcePathStyle: {{ .s3ForcePathStyle | quote }}
{{- end }}

checks for .s3ForcePathStyle and populates it with string value (if set to 'true').

This causes commands such as: 
helm template <release_name> <chart> --version <chart_version>
OR
helm install <release_name> <chart> --version <chart_version> --dry-run --debug
to produce the following manifest for backupstoragelocation.yaml with 's3ForcePathStyle' mentioned twice with values of different datatypes.
---
apiVersion: velero.io/v1
kind: BackupStorageLocation
metadata:
  name: default
  annotations:
    "helm.sh/hook": post-install,post-upgrade
    "helm.sh/hook-delete-policy": "before-hook-creation"
  labels:
    app.kubernetes.io/name: <chart>
    app.kubernetes.io/instance: <release_name>
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: <chart>-<version>
spec:
  provider: <provider>
  objectStorage:
    bucket: <bucket_name>
  config:
    region: <region>
    s3ForcePathStyle: true
    s3Url: <s3_url>
    s3ForcePathStyle: "true"


This change fixes that issue. Even though k8s takes care of this automatically, but this fix would provide a better and cleaner way to deploy the backupstoragelocation.yaml and mitigate any errors that might arise because of this.
This change has been tried and tested successfully, and can be tested again locally before the approval.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[velero]`)
