### PR TITLE
[velero] feat(schedule): add annotation templating

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.5.2
 description: A Helm chart for velero
 name: velero
-version: 2.14.4
+version: 2.14.5
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/schedule.yaml
+++ b/charts/velero/templates/schedule.yaml
@@ -4,6 +4,9 @@ kind: Schedule
 metadata:
   name: {{ include "velero.fullname" $ }}-{{ $scheduleName }}
   annotations:
+  {{- if $schedule.annotations }}
+    {{- toYaml $schedule.annotations | nindent 4 }}
+  {{- end }}
   {{- if $.Values.enableHelmHooks }}
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -276,6 +276,8 @@ restic:
 #   mybackup:
 #     labels:
 #       myenv: foo
+#     annotations:
+#       myenv: foo
 #     schedule: "0 0 * * *"
 #     template:
 #       ttl: "240h"


### PR DESCRIPTION
#### Special notes for your reviewer:
As with https://github.com/vmware-tanzu/velero/pull/3067, annotations of the schedule get propagated into the backups. This allows us to set annotations on schedules over this chart.

**Attention:** https://github.com/vmware-tanzu/velero/pull/3067 isn't yet released. 

#### Checklist
<!--[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]-->
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
