### PR TITLE
add stable repo to the new location

### DIFF
--- a/ct.yaml
+++ b/ct.yaml
@@ -4,3 +4,5 @@ chart-dirs:
 remote: origin
 target-branch: main
 upgrade: true
+chart-repos:
+  - stable=https://charts.helm.sh/stable


### PR DESCRIPTION
#### Special notes for your reviewer:
the old stable path (https://kubernetes-charts.storage.googleapis.com) does not exist anymore and was replaces to https://charts.helm.sh/stable

our pipeline is pointing to the old one as we can see here: https://github.com/vmware-tanzu/helm-charts/pull/201/checks?check_run_id=1713794402

this PR just set the new path to be used





#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the values.yaml or README.md
- [ ] Title of the PR starts with chart name (e.g. `[velero]`)
