### PR TITLE
[velero] Helm2 fix

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -41,6 +41,7 @@ jobs:
         id: lint
         uses: helm/chart-testing-action@v1.0.0-alpha.3 # fixed on v1.0.0-alpha.3 for helm2
         with:
+          image: quay.io/cpanato/chart-testing:dev-v2-latest
           command: lint
 
       - name: Create kind cluster
@@ -51,4 +52,5 @@ jobs:
       - name: Run chart-testing (install)
         uses: helm/chart-testing-action@v1.0.0-alpha.3 # fixed on v1.0.0-alpha.3 for helm2
         with:
+          image: quay.io/cpanato/chart-testing:dev-v2-latest
           command: install

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.5.2
 description: A Helm chart for velero
 name: velero
-version: 2.14.5
+version: 2.14.6
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:
@@ -18,4 +18,3 @@ maintainers:
     email: brubakern@vmware.com
   - name: skriss
     email: krisss@vmware.com
-tillerVersion: ">=2.10.0"


### PR DESCRIPTION
#### Special notes for your reviewer:

The previous helm releases (<2.17) had the stable repository hardcoded, the problem is the URL does not exist anymore. 
So using the last helm v2 release 2.17.0 solves the issue.

We use the `chart-testing` to run all tests, in the helm side we are checking if we will release a final `chart-testing` for V2 or not, so in meantime, I've pushed the `chart-testing` image to my quay.io repo and we can use that and unblock the pipeline for v2

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
