### PR TITLE
[velero] allow disabling schedule in value overrides

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.5.3
 description: A Helm chart for velero
 name: velero
-version: 2.14.7
+version: 2.14.8
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/schedule.yaml
+++ b/charts/velero/templates/schedule.yaml
@@ -1,4 +1,5 @@
 {{- range $scheduleName, $schedule := .Values.schedules }}
+{{- if (not $schedule.disabled) }}
 apiVersion: velero.io/v1
 kind: Schedule
 metadata:
@@ -26,4 +27,5 @@ spec:
     {{- toYaml . | nindent 4 }}
 {{- end }}
 ---
+{{- end }}
 {{- end }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -274,6 +274,7 @@ restic:
 # Eg:
 # schedules:
 #   mybackup:
+#     disabled: false
 #     labels:
 #       myenv: foo
 #     annotations:


### PR DESCRIPTION
#### Special notes for your reviewer:

In multi-layer environment where several values files are applied, it is very useful to allow disabling a schedule that is defined in a common values file.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
