### PR TITLE
[velero] feat: allow servicemonitor to be deployed in another namespace

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.5.3
 description: A Helm chart for velero
 name: velero
-version: 2.14.7
+version: 2.14.8
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/servicemonitor.yaml
+++ b/charts/velero/templates/servicemonitor.yaml
@@ -3,6 +3,9 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "velero.fullname" . }}
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -12,6 +15,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "velero.name" . }}
@@ -19,4 +25,5 @@ spec:
   endpoints:
   - port: monitoring
     interval: {{ .Values.metrics.scrapeInterval }}
+    scrapeTimeout: {{ .Values.metrics.scrapeTimeout }}
 {{- end }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -70,6 +70,7 @@ extraVolumeMounts: []
 metrics:
   enabled: true
   scrapeInterval: 30s
+  scrapeTimeout: 10s
 
   # Pod annotations for Prometheus
   podAnnotations:
@@ -80,6 +81,8 @@ metrics:
   serviceMonitor:
     enabled: false
     additionalLabels: {}
+    # Deploy Service Monitor to another namespace
+    namespace:
 
 # Install CRDs as a templates. Enabled by default.
 installCRDs: true


### PR DESCRIPTION
#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
