### PR TITLE
[Velero] Add velero component label and update docs

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.5.3
 description: A Helm chart for velero
 name: velero
-version: 2.14.8
+version: 2.14.9
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/README.md
+++ b/charts/velero/README.md
@@ -69,7 +69,7 @@ helm install vmware-tanzu/velero --namespace <YOUR NAMESPACE> -f values.yaml --g
 If a value needs to be added or changed, you may do so with the `upgrade` command. An example:
 
 ```bash
-    helm upgrade vmware-tanzu/velero <RELEASE NAME> --namespace <YOUR NAMESPACE> --reuse-values --set configuration.provider=<NEW PROVIDER>
+helm upgrade vmware-tanzu/velero <RELEASE NAME> --namespace <YOUR NAMESPACE> --reuse-values --set configuration.provider=<NEW PROVIDER>
 ```
 
 #### Using Helm 2
@@ -107,6 +107,8 @@ helm install vmware-tanzu/velero \
 --set initContainers[0].volumeMounts[0].mountPath=/target \
 --set initContainers[0].volumeMounts[0].name=plugins 
 ```
+
+Users of zsh might need to put quotes around key/value pairs.
 
 ##### Option 2) YAML file
 

--- a/charts/velero/README.md
+++ b/charts/velero/README.md
@@ -24,6 +24,9 @@ The default configuration values for this chart are listed in values.yaml.
 
 See Velero's full [official documentation](https://velero.io/docs/v1.5/basic-install/). More specifically, find your provider in the Velero list of [supported providers](https://velero.io/docs/v1.5/supported-providers/) for specific configuration information and examples.
 
+#### Set up Helm
+
+See the main [README.md](https://github.com/vmware-tanzu/helm-charts#kubernetes-helm-charts-for-vmware-tanzu).
 
 #### Using Helm 3
 
@@ -36,7 +39,7 @@ Please note that cleaning up CRDs will also delete any CRD instance, such as Bac
 Specify the necessary values using the --set key=value[,key=value] argument to helm install. For example,
 
 ```bash
-helm install vmware-tanzu/velero \
+helm install velero vmware-tanzu/velero \
 --namespace <YOUR NAMESPACE> \
 --create-namespace \
 --set-file credentials.secretContents.cloud=<FULL PATH TO FILE> \
@@ -50,8 +53,9 @@ helm install vmware-tanzu/velero \
 --set initContainers[0].image=velero/velero-plugin-for-<PROVIDER NAME>:<PROVIDER PLUGIN TAG> \
 --set initContainers[0].volumeMounts[0].mountPath=/target \
 --set initContainers[0].volumeMounts[0].name=plugins \
---generate-name
 ```
+
+Users of zsh might need to put quotes around key/value pairs.
 
 ##### Option 2) YAML file
 
@@ -65,7 +69,7 @@ helm install vmware-tanzu/velero --namespace <YOUR NAMESPACE> -f values.yaml --g
 If a value needs to be added or changed, you may do so with the `upgrade` command. An example:
 
 ```bash
-helm upgrade vmware-tanzu/velero <RELEASE NAME> --namespace <YOUR NAMESPACE> --reuse-values --set configuration.provider=<NEW PROVIDER>
+    helm upgrade vmware-tanzu/velero <RELEASE NAME> --namespace <YOUR NAMESPACE> --reuse-values --set configuration.provider=<NEW PROVIDER>
 ```
 
 #### Using Helm 2

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "velero.chart" . }}
+    component: velero
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
Relates to changes made by [vmware-tanzu/velero PR3447](https://github.com/vmware-tanzu/velero/pull/3447). 
- add `component=velero` label
- remove `--generate-name` and use "velero" as name.
- update documentation

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
