### PR TITLE
[velero] feat: add annotations for velero deployment and restic daemonset

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.5.3
 description: A Helm chart for velero
 name: velero
-version: 2.14.10
+version: 2.14.11
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -4,11 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "velero.fullname" . }}
-  {{- if .Values.deploymentAnnotations }}
+  {{- with .Values.annotations }}
   annotations:
-    {{- with .Values.deploymentAnnotations }}
-      {{- toYaml . | nindent 6 }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}
@@ -16,6 +14,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "velero.chart" . }}
     component: velero
+    {{- with .Values.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: 1
   selector:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -4,10 +4,12 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "velero.fullname" . }}
+  {{- if .Values.deploymentAnnotations }}
   annotations:
     {{- with .Values.deploymentAnnotations }}
       {{- toYaml . | nindent 6 }}
     {{- end }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -4,6 +4,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "velero.fullname" . }}
+  annotations:
+    {{- with .Values.deploymentAnnotations }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/velero/templates/restic-daemonset.yaml
+++ b/charts/velero/templates/restic-daemonset.yaml
@@ -4,17 +4,18 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: restic
-  {{- if .Values.restic.daemonsetAnnotations }}
+  {{- with .Values.restic.annotations }}
   annotations:
-    {{- with .Values.restic.daemonsetAnnotations }}
-      {{- toYaml . | nindent 6 }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "velero.chart" . }}
+    {{- with .Values.restic.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/velero/templates/restic-daemonset.yaml
+++ b/charts/velero/templates/restic-daemonset.yaml
@@ -4,10 +4,12 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: restic
+  {{- if .Values.restic.daemonsetAnnotations }}
   annotations:
     {{- with .Values.restic.daemonsetAnnotations }}
       {{- toYaml . | nindent 6 }}
     {{- end }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/velero/templates/restic-daemonset.yaml
+++ b/charts/velero/templates/restic-daemonset.yaml
@@ -4,6 +4,10 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: restic
+  annotations:
+    {{- with .Values.restic.daemonsetAnnotations }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/velero/templates/service.yaml
+++ b/charts/velero/templates/service.yaml
@@ -3,11 +3,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "velero.fullname" . }}
+  {{- with .Values.metrics.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "velero.chart" . }}
+    {{- with .Values.metrics.service.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -15,6 +15,12 @@ image:
   imagePullSecrets: []
   # - registrySecretName
 
+# Annotations to add to the Velero deployment's. Optional.
+#
+# If you are using reloader use the following annotation with your VELERO_SECRET_NAME
+deploymentAnnotations: {}
+  # secret.reloader.stakater.com/reload: "<VELERO_SECRET_NAME>"
+
 # Annotations to add to the Velero deployment's pod template. Optional.
 #
 # If using kube2iam or kiam, use the following annotation with your AWS_ACCOUNT_ID
@@ -261,6 +267,9 @@ restic:
   resources: {}
   # Tolerations to use for the Restic daemonset. Optional.
   tolerations: []
+
+  # Annotations to set for the Restic daemonset. Optional.
+  daemonsetAnnotations: {}
 
   # Extra volumes for the Restic daemonset. Optional.
   extraVolumes: []

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -18,8 +18,11 @@ image:
 # Annotations to add to the Velero deployment's. Optional.
 #
 # If you are using reloader use the following annotation with your VELERO_SECRET_NAME
-deploymentAnnotations: {}
-  # secret.reloader.stakater.com/reload: "<VELERO_SECRET_NAME>"
+annotations: {}
+# secret.reloader.stakater.com/reload: "<VELERO_SECRET_NAME>"
+
+# Labels to add to the Velero deployment's. Optional.
+labels: {}
 
 # Annotations to add to the Velero deployment's pod template. Optional.
 #
@@ -77,6 +80,11 @@ metrics:
   enabled: true
   scrapeInterval: 30s
   scrapeTimeout: 10s
+
+  # service metdata if metrics are enabled
+  service:
+    annotations: {}
+    labels: {}
 
   # Pod annotations for Prometheus
   podAnnotations:
@@ -269,7 +277,10 @@ restic:
   tolerations: []
 
   # Annotations to set for the Restic daemonset. Optional.
-  daemonsetAnnotations: {}
+  annotations: {}
+
+  # labels to set for the Restic daemonset. Optional.
+  labels: {}
 
   # Extra volumes for the Restic daemonset. Optional.
   extraVolumes: []


### PR DESCRIPTION
#### Special notes for your reviewer:
This PR adds:

    Ability to set annotation and label on Velero deployment
    Ability to set annotation and label on Restic daemonset
    Ability to set annotation and label on velero service

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
