### PR TITLE
[velero] customize client-qps and client-burst

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.5.3
 description: A Helm chart for velero
 name: velero
-version: 2.14.9
+version: 2.14.10
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -90,6 +90,12 @@ spec:
             {{- if .defaultVolumesToRestic }}
             - --default-volumes-to-restic
             {{- end }}
+            {{- with .clientQPS }}
+            - --client-qps={{ . }}
+            {{- end }}
+            {{- with .clientBurst }}
+            - --client-burst={{ . }}
+            {{- end }}
           {{- end }}
           {{- with .Values.resources }}
           resources:

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -168,6 +168,11 @@ configuration:
   restoreResourcePriorities:
   # `velero server` default: false
   restoreOnlyMode:
+  # `velero server` default: 20.0
+  clientQPS:
+  # `velero server` default: 30
+  clientBurst:
+  #
 
   # additional key/value pairs to be used as environment variables such as "AWS_CLUSTER_NAME: 'yourcluster.domain.tld'"
   extraEnvVars: {}


### PR DESCRIPTION
Signed-off-by: Tareq Sharafy <tareq.sha@gmail.com>

#### Special notes for your reviewer:

This change allows a users to customize client QPS and burst rate flexibly according to the load in their setups from the chart directly without applying ad-hoc modifications or relying on hard-coded defaults.

Avoid running into performances issues as described in https://github.com/vmware-tanzu/velero/issues/3191

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
