### PR TITLE
[velero] Fix `helm upgrade` does not upgrade the CRDs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,8 +23,6 @@ about: Tell us about a problem you are experiencing
 
 - helm version (use `helm version`): 
 - helm chart version and app version:
-  - helm2 (use `helm list`):
-  - helm3 (use `helm list -n <YOUR NAMESPACE>`):
 - Kubernetes version (use `kubectl version`):
 - Kubernetes installer & version:
 - Cloud provider or hardware configuration:

--- a/.github/ISSUE_TEMPLATE/feature-enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-enhancement-request.md
@@ -20,8 +20,6 @@ about: Suggest an idea for this project
 
 - helm version (use `helm version`): 
 - helm chart version and app version:
-  - helm2 (use `helm list`):
-  - helm3 (use `helm list -n <YOUR NAMESPACE>`):
 - Kubernetes version (use `kubectl version`):
 - Kubernetes installer & version:
 - Cloud provider or hardware configuration:

--- a/.github/workflows/auto_assign_prs.yml
+++ b/.github/workflows/auto_assign_prs.yml
@@ -3,8 +3,7 @@ name: 'Auto Assign PR Reviewers'
 # This should mean PRs from forks are supported.
 on: 
   pull_request_target:
-    types: [opened, reopened, sychronized]
-
+    types: [opened, reopened, sychronized, ready_for_review]
 
 jobs: 
   add-reviews:

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.5.3
 description: A Helm chart for velero
 name: velero
-version: 2.16.0
+version: 2.17.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/README.md
+++ b/charts/velero/README.md
@@ -51,7 +51,7 @@ helm install velero vmware-tanzu/velero \
 --set initContainers[0].name=velero-plugin-for-<PROVIDER NAME> \
 --set initContainers[0].image=velero/velero-plugin-for-<PROVIDER NAME>:<PROVIDER PLUGIN TAG> \
 --set initContainers[0].volumeMounts[0].mountPath=/target \
---set initContainers[0].volumeMounts[0].name=plugins \
+--set initContainers[0].volumeMounts[0].name=plugins
 ```
 
 Users of zsh might need to put quotes around key/value pairs.
@@ -113,5 +113,5 @@ Note: when you uninstall the Velero server, all backups remain untouched.
 ### Using Helm 3
 
 ```bash
-helm delete <RELEASE NAME> -n <YOUR NAMESPACE>
+helm uninstall <RELEASE NAME> -n <YOUR NAMESPACE>
 ```

--- a/charts/velero/crds/backups.yaml
+++ b/charts/velero/crds/backups.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: velero
+    component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   name: backups.velero.io

--- a/charts/velero/crds/backupstoragelocations.yaml
+++ b/charts/velero/crds/backupstoragelocations.yaml
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: "velero"
+    app.kubernetes.io/name: velero
+    component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   name: backupstoragelocations.velero.io

--- a/charts/velero/crds/deletebackuprequests.yaml
+++ b/charts/velero/crds/deletebackuprequests.yaml
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: "velero"
+    app.kubernetes.io/name: velero
+    component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   name: deletebackuprequests.velero.io

--- a/charts/velero/crds/downloadrequests.yaml
+++ b/charts/velero/crds/downloadrequests.yaml
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: "velero"
+    app.kubernetes.io/name: velero
+    component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   name: downloadrequests.velero.io

--- a/charts/velero/crds/podvolumebackups.yaml
+++ b/charts/velero/crds/podvolumebackups.yaml
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: "velero"
+    app.kubernetes.io/name: velero
+    component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   name: podvolumebackups.velero.io

--- a/charts/velero/crds/podvolumerestores.yaml
+++ b/charts/velero/crds/podvolumerestores.yaml
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: "velero"
+    app.kubernetes.io/name: velero
+    component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   name: podvolumerestores.velero.io

--- a/charts/velero/crds/resticrepositories.yaml
+++ b/charts/velero/crds/resticrepositories.yaml
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: "velero"
+    app.kubernetes.io/name: velero
+    component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   name: resticrepositories.velero.io

--- a/charts/velero/crds/restores.yaml
+++ b/charts/velero/crds/restores.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: velero
+    component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   name: restores.velero.io

--- a/charts/velero/crds/schedules.yaml
+++ b/charts/velero/crds/schedules.yaml
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: "velero"
+    app.kubernetes.io/name: velero
+    component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   name: schedules.velero.io

--- a/charts/velero/crds/serverstatusrequests.yaml
+++ b/charts/velero/crds/serverstatusrequests.yaml
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: "velero"
+    app.kubernetes.io/name: velero
+    component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   name: serverstatusrequests.velero.io

--- a/charts/velero/crds/volumesnapshotlocations.yaml
+++ b/charts/velero/crds/volumesnapshotlocations.yaml
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: "velero"
+    app.kubernetes.io/name: velero
+    component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   name: volumesnapshotlocations.velero.io

--- a/charts/velero/templates/backupstoragelocation.yaml
+++ b/charts/velero/templates/backupstoragelocation.yaml
@@ -4,7 +4,7 @@ kind: BackupStorageLocation
 metadata:
   name: {{ include "velero.backupStorageLocation.name" . }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
     "helm.sh/hook-delete-policy": "before-hook-creation"
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}

--- a/charts/velero/templates/cleanup-crds.yaml
+++ b/charts/velero/templates/cleanup-crds.yaml
@@ -4,11 +4,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "velero.fullname" . }}-cleanup
+  name: {{ template "velero.fullname" . }}-cleanup-crds
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-delete
-    "helm.sh/hook-weight": "3"
     "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}
@@ -18,7 +17,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: velero-cleanup
+      name: velero-cleanup-crds
     spec:
       serviceAccountName: {{ include "velero.serverServiceAccount" . }}
       containers:

--- a/charts/velero/templates/schedule.yaml
+++ b/charts/velero/templates/schedule.yaml
@@ -7,7 +7,7 @@ metadata:
   {{- if $schedule.annotations }}
     {{- toYaml $schedule.annotations | nindent 4 }}
   {{- end }}
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
     "helm.sh/hook-delete-policy": "before-hook-creation"
   labels:
     app.kubernetes.io/name: {{ include "velero.name" $ }}

--- a/charts/velero/templates/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds.yaml
@@ -1,0 +1,32 @@
+{{- if .Release.IsUpgrade }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "velero.fullname" . }}-upgrade-crds
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+spec:
+  template:
+    metadata:
+      name: velero-upgrade-crds
+    spec:
+      serviceAccountName: {{ include "velero.serverServiceAccount" . }}
+      containers:
+        - name: velero
+      {{- if .Values.image.digest }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+      {{- else }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+      {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /velero
+          args:
+            - install
+            - --crds-only
+      restartPolicy: OnFailure
+{{- end }}

--- a/charts/velero/templates/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds.yaml
@@ -24,9 +24,25 @@ spec:
       {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
-            - /velero
-          args:
-            - install
-            - --crds-only
+            - /bin/sh
+            - -c
+            - /velero install --crds-only --dry-run -o yaml > /tmp/crds.yaml
+          volumeMounts:
+            - mountPath: /tmp
+              name: crds
+      containers:
+        - name: kubectl
+          image: docker.io/bitnami/kubectl:1.14.1
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - kubectl apply -f /tmp/crds.yaml
+          volumeMounts:
+            - mountPath: /tmp
+              name: crds
+      volumes:
+        - name: crds
+          emptyDir: {}
       restartPolicy: OnFailure
 {{- end }}

--- a/charts/velero/templates/volumesnapshotlocation.yaml
+++ b/charts/velero/templates/volumesnapshotlocation.yaml
@@ -4,7 +4,7 @@ kind: VolumeSnapshotLocation
 metadata:
   name: {{ include "velero.volumeSnapshotLocation.name" . }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
     "helm.sh/hook-delete-policy": "before-hook-creation"
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}


### PR DESCRIPTION
#### Special notes for your reviewer:

The helm [built-in objects](https://helm.sh/docs/chart_template_guide/builtin_objects/) `Release.IsUpgrade` specifies the current operation is an upgrade or rollback. We could use it to determine whether to create a job to upgrade _or_ rollback the CRDs when the user performs `helm upgrade` _or_ `helm rollback`.

Also, we have configured these CRs to apply to the cluster:
1. backupstoragelocations.yaml
1. schedules.yaml
1. volumesnapshotlocation.yaml

We _must_ make sure the upgrade/rollback CRDs job finished then apply these CRs manifest.
According to https://helm.sh/docs/topics/charts_hooks/, so we add the `post-upgrade` and `post-rollback` to these CRs to make sure that the CRs will wait for the upgrade/rollback CRDs job runs to completion and then, apply the CRs manifest.

BTW, since velero CLI installed CRDs are with labels `component: velero`. To make sure both CLI installed Velero _or_ helm installed Velero having the same labels, we add label `component: velero` to the CRDs.

fixes #197

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
