### PR TITLE
[velero] Fix Azure plugin VSL configuration

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.6.0
 description: A Helm chart for velero
 name: velero
-version: 2.18.0
+version: 2.18.1
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/volumesnapshotlocation.yaml
+++ b/charts/velero/templates/volumesnapshotlocation.yaml
@@ -15,6 +15,8 @@ spec:
   provider: {{ include "velero.volumeSnapshotLocation.provider" . }}
 {{- with .Values.configuration.volumeSnapshotLocation.config }}
   config:
-{{ toYaml . | indent 4 }}
+{{- range $key, $value := . }}
+{{- $key | nindent 4 }}: {{ $value | quote }}
+{{- end }}
 {{- end -}}
 {{- end }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -161,10 +161,11 @@ configuration:
     # for details of required/optional fields for your provider.
     config: {}
   #    region:
-  #    apitimeout:
+  #    apiTimeout:
   #    resourceGroup:
   #    The ID of the subscription where volume snapshots should be stored, if different from the cluster’s subscription. If specified, also requires `configuration.volumeSnapshotLocation.config.resourceGroup`to be set. (Azure only)
   #    subscriptionId:
+  #    incremental:
   #    snapshotLocation:
   #    project:
 


### PR DESCRIPTION
#### Special notes for your reviewer:

According to https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/blob/v1.2.0/velero-plugin-for-microsoft-azure/volume_snapshotter.go#L78, the configuration pass to the plugin would be `map[string]string`. So, we should quote the config key-value pair as string-string, which means always quote the value as `string` type.

The plugin would parse the `string` type to `bool` by themselves https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/blob/v1.2.0/velero-plugin-for-microsoft-azure/volume_snapshotter.go#L139.

~fixes https://github.com/vmware-tanzu/velero/issues/3214~

fixes https://github.com/vmware-tanzu/helm-charts/issues/250

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
