### PR TITLE
[velero] Fix "s3ForcePathStyle" entry gets duplicated with AWS plugin

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.6.0
 description: A Helm chart for velero
 name: velero
-version: 2.18.1
+version: 2.18.2
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/backupstoragelocation.yaml
+++ b/charts/velero/templates/backupstoragelocation.yaml
@@ -24,9 +24,8 @@ spec:
     {{- end }}
 {{- with .config }}
   config:
-{{ toYaml . | indent 4}}
-{{- if .s3ForcePathStyle }}
-    s3ForcePathStyle: {{ .s3ForcePathStyle | quote }}
+{{- range $key, $value := . }}
+{{- $key | nindent 4 }}: {{ $value | quote }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
#### Special notes for your reviewer:

According to https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/v1.2.0/velero-plugin-for-aws/object_store.go#L87, the configuration pass to the plugin would be `map[string]string`. So, we should quote the config key-value pair as string-string, which means always quote the value as `string` type.

The plugin would parse the `string` type to `bool` by themselves https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/v1.2.0/velero-plugin-for-aws/object_store.go#L127.

fixes #219

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] ~Variables are documented in the values.yaml or README.md~
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
