### PR TITLE
[velero] Bump Velero version to v1.6.0 and plugin version to v1.2.0

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.5.3
+appVersion: 1.6.0
 description: A Helm chart for velero
 name: velero
-version: 2.16.0
+version: 2.17.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/README.md
+++ b/charts/velero/README.md
@@ -85,10 +85,13 @@ helm upgrade vmware-tanzu/velero <RELEASE NAME> --reuse-values --set configurati
 
 ## Upgrading
 
+### Upgrading to v1.6
+
+The [instructions found here](https://velero.io/docs/v1.6/upgrade-to-1.6/) will assist you in upgrading from version v1.5.x to v1.6.
+
 ### Upgrading to v1.5
 
 The [instructions found here](https://velero.io/docs/v1.5/upgrade-to-1.5/) will assist you in upgrading from version v1.4.x to v1.5.
-
 
 ### Upgrading to v1.4
 

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -6,7 +6,7 @@
 # enabling restic). Required.
 image:
   repository: velero/velero
-  tag: v1.5.3
+  tag: v1.6.0
   # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38. If used, it will
   # take precedence over the image.tag.
   # digest:
@@ -45,7 +45,7 @@ dnsPolicy: ClusterFirst
 # Init containers to add to the Velero deployment's pod spec. At least one plugin provider image is required.
 initContainers: []
   # - name: velero-plugin-for-aws
-  #   image: velero/velero-plugin-for-aws:v1.1.0
+  #   image: velero/velero-plugin-for-aws:v1.2.0
   #   imagePullPolicy: IfNotPresent
   #   volumeMounts:
   #     - mountPath: /target


### PR DESCRIPTION
#### Special notes for your reviewer:

- Bump Velero version to v1.6.0
- Bump aws example plugin version to v1.2.0

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
