### PR TITLE
[velero] Fix `helm upgrade` does not upgrade the CRDs

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.6.0
 description: A Helm chart for velero
 name: velero
-version: 2.18.2
+version: 2.19.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/README.md
+++ b/charts/velero/README.md
@@ -6,13 +6,13 @@ Velero has two main components: a CLI, and a server-side Kubernetes deployment.
 
 ## Installing the Velero CLI
 
-See the different options for installing the [Velero CLI](https://velero.io/docs/v1.5/basic-install/#install-the-cli).
+See the different options for installing the [Velero CLI](https://velero.io/docs/v1.6/basic-install/#install-the-cli).
 
 ## Installing the Velero server
 
 ### Velero version
 
-This helm chart installs Velero version v1.5 https://velero.io/docs/v1.5/. See the [#Upgrading](#upgrading) section for information on how to upgrade from other versions.
+This helm chart installs Velero version v1.6 https://velero.io/docs/v1.6/. See the [#Upgrading](#upgrading) section for information on how to upgrade from other versions.
 
 ### Provider credentials
 
@@ -22,7 +22,7 @@ When installing using the Helm chart, the provider's credential information will
 
 The default configuration values for this chart are listed in values.yaml.
 
-See Velero's full [official documentation](https://velero.io/docs/v1.5/basic-install/). More specifically, find your provider in the Velero list of [supported providers](https://velero.io/docs/v1.5/supported-providers/) for specific configuration information and examples.
+See Velero's full [official documentation](https://velero.io/docs/v1.6/basic-install/). More specifically, find your provider in the Velero list of [supported providers](https://velero.io/docs/v1.6/supported-providers/) for specific configuration information and examples.
 
 #### Set up Helm
 

--- a/charts/velero/README.md
+++ b/charts/velero/README.md
@@ -51,7 +51,7 @@ helm install velero vmware-tanzu/velero \
 --set initContainers[0].name=velero-plugin-for-<PROVIDER NAME> \
 --set initContainers[0].image=velero/velero-plugin-for-<PROVIDER NAME>:<PROVIDER PLUGIN TAG> \
 --set initContainers[0].volumeMounts[0].mountPath=/target \
---set initContainers[0].volumeMounts[0].name=plugins \
+--set initContainers[0].volumeMounts[0].name=plugins
 ```
 
 Users of zsh might need to put quotes around key/value pairs.
@@ -116,5 +116,5 @@ Note: when you uninstall the Velero server, all backups remain untouched.
 ### Using Helm 3
 
 ```bash
-helm delete <RELEASE NAME> -n <YOUR NAMESPACE>
+helm uninstall <RELEASE NAME> -n <YOUR NAMESPACE>
 ```

--- a/charts/velero/crds/backups.yaml
+++ b/charts/velero/crds/backups.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: velero
+    component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null

--- a/charts/velero/crds/backupstoragelocations.yaml
+++ b/charts/velero/crds/backupstoragelocations.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: velero
+    component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null

--- a/charts/velero/crds/deletebackuprequests.yaml
+++ b/charts/velero/crds/deletebackuprequests.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: velero
+    component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null

--- a/charts/velero/crds/downloadrequests.yaml
+++ b/charts/velero/crds/downloadrequests.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: velero
+    component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null

--- a/charts/velero/crds/podvolumebackups.yaml
+++ b/charts/velero/crds/podvolumebackups.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: velero
+    component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null

--- a/charts/velero/crds/podvolumerestores.yaml
+++ b/charts/velero/crds/podvolumerestores.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: velero
+    component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null

--- a/charts/velero/crds/resticrepositories.yaml
+++ b/charts/velero/crds/resticrepositories.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: velero
+    component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null

--- a/charts/velero/crds/restores.yaml
+++ b/charts/velero/crds/restores.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: velero
+    component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null

--- a/charts/velero/crds/schedules.yaml
+++ b/charts/velero/crds/schedules.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: velero
+    component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null

--- a/charts/velero/crds/serverstatusrequests.yaml
+++ b/charts/velero/crds/serverstatusrequests.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: velero
+    component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null

--- a/charts/velero/crds/volumesnapshotlocations.yaml
+++ b/charts/velero/crds/volumesnapshotlocations.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: velero
+    component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null

--- a/charts/velero/templates/backupstoragelocation.yaml
+++ b/charts/velero/templates/backupstoragelocation.yaml
@@ -4,7 +4,7 @@ kind: BackupStorageLocation
 metadata:
   name: {{ include "velero.backupStorageLocation.name" . }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
     "helm.sh/hook-delete-policy": "before-hook-creation"
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}

--- a/charts/velero/templates/backupstoragelocation.yaml
+++ b/charts/velero/templates/backupstoragelocation.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "velero.backupStorageLocation.name" . }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade,post-rollback
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-delete-policy": before-hook-creation
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/velero/templates/cleanup-crds.yaml
+++ b/charts/velero/templates/cleanup-crds.yaml
@@ -4,11 +4,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "velero.fullname" . }}-cleanup
+  name: {{ template "velero.fullname" . }}-cleanup-crds
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-delete
-    "helm.sh/hook-weight": "3"
     "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}
@@ -18,7 +17,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: velero-cleanup
+      name: velero-cleanup-crds
     spec:
       serviceAccountName: {{ include "velero.serverServiceAccount" . }}
       containers:

--- a/charts/velero/templates/cleanup-crds.yaml
+++ b/charts/velero/templates/cleanup-crds.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "velero.chart" . }}
 spec:
+  backoffLimit: 3
   template:
     metadata:
       name: velero-cleanup-crds

--- a/charts/velero/templates/cleanup-crds.yaml
+++ b/charts/velero/templates/cleanup-crds.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: {{ include "velero.serverServiceAccount" . }}
       containers:
         - name: kubectl
-          image: docker.io/bitnami/kubectl:1.14.1
+          image: docker.io/bitnami/kubectl:1.14.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/charts/velero/templates/schedule.yaml
+++ b/charts/velero/templates/schedule.yaml
@@ -7,7 +7,7 @@ metadata:
   {{- if $schedule.annotations }}
     {{- toYaml $schedule.annotations | nindent 4 }}
   {{- end }}
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
     "helm.sh/hook-delete-policy": "before-hook-creation"
   labels:
     app.kubernetes.io/name: {{ include "velero.name" $ }}

--- a/charts/velero/templates/schedule.yaml
+++ b/charts/velero/templates/schedule.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- toYaml $schedule.annotations | nindent 4 }}
   {{- end }}
     "helm.sh/hook": post-install,post-upgrade,post-rollback
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-delete-policy": before-hook-creation
   labels:
     app.kubernetes.io/name: {{ include "velero.name" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}

--- a/charts/velero/templates/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds.yaml
@@ -1,0 +1,32 @@
+{{- if .Release.IsUpgrade }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "velero.fullname" . }}-upgrade-crds
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+spec:
+  template:
+    metadata:
+      name: velero-upgrade-crds
+    spec:
+      serviceAccountName: {{ include "velero.serverServiceAccount" . }}
+      containers:
+        - name: velero
+      {{- if .Values.image.digest }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+      {{- else }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+      {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /velero
+          args:
+            - install
+            - --crds-only
+      restartPolicy: OnFailure
+{{- end }}

--- a/charts/velero/templates/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds.yaml
@@ -15,7 +15,7 @@ spec:
       name: velero-upgrade-crds
     spec:
       serviceAccountName: {{ include "velero.serverServiceAccount" . }}
-      containers:
+      initContainers:
         - name: velero
       {{- if .Values.image.digest }}
           image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"

--- a/charts/velero/templates/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds.yaml
@@ -24,9 +24,25 @@ spec:
       {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
-            - /velero
-          args:
-            - install
-            - --crds-only
+            - /bin/sh
+            - -c
+            - /velero install --crds-only --dry-run -o yaml > /tmp/crds.yaml
+          volumeMounts:
+            - mountPath: /tmp
+              name: crds
+      containers:
+        - name: kubectl
+          image: docker.io/bitnami/kubectl:1.14.1
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - kubectl apply -f /tmp/crds.yaml
+          volumeMounts:
+            - mountPath: /tmp
+              name: crds
+      volumes:
+        - name: crds
+          emptyDir: {}
       restartPolicy: OnFailure
 {{- end }}

--- a/charts/velero/templates/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds.yaml
@@ -1,9 +1,11 @@
-{{- if .Release.IsUpgrade }}
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "velero.fullname" . }}-upgrade-crds
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -46,4 +48,3 @@ spec:
         - name: crds
           emptyDir: {}
       restartPolicy: OnFailure
-{{- end }}

--- a/charts/velero/templates/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "velero.chart" . }}
 spec:
+  backoffLimit: 3
   template:
     metadata:
       name: velero-upgrade-crds

--- a/charts/velero/templates/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds.yaml
@@ -33,7 +33,7 @@ spec:
               name: crds
       containers:
         - name: kubectl
-          image: docker.io/bitnami/kubectl:1.14.1
+          image: docker.io/bitnami/kubectl:1.14.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/charts/velero/templates/volumesnapshotlocation.yaml
+++ b/charts/velero/templates/volumesnapshotlocation.yaml
@@ -4,7 +4,7 @@ kind: VolumeSnapshotLocation
 metadata:
   name: {{ include "velero.volumeSnapshotLocation.name" . }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
     "helm.sh/hook-delete-policy": "before-hook-creation"
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}

--- a/charts/velero/templates/volumesnapshotlocation.yaml
+++ b/charts/velero/templates/volumesnapshotlocation.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "velero.volumeSnapshotLocation.name" . }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade,post-rollback
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-delete-policy": before-hook-creation
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -119,7 +119,7 @@ configuration:
   provider:
 
   # Parameters for the `default` BackupStorageLocation. See
-  # https://velero.io/docs/v1.5/api-types/backupstoragelocation/
+  # https://velero.io/docs/main/api-types/backupstoragelocation/
   backupStorageLocation:
     # name is the name of the backup storage location where backups should be stored. If a name is not provided,
     # a backup storage location will be created with the name "default". Optional.
@@ -150,7 +150,7 @@ configuration:
     #  serviceAccount:
 
   # Parameters for the `default` VolumeSnapshotLocation. See
-  # https://velero.io/docs/v1.5/api-types/volumesnapshotlocation/
+  # https://velero.io/docs/main/api-types/volumesnapshotlocation/
   volumeSnapshotLocation:
     # name is the name of the volume snapshot location where snapshots are being taken. Required.
     name:
@@ -335,7 +335,7 @@ schedules: {}
 #       velero.io/plugin-config: ""
 #       velero.io/restic: RestoreItemAction
 #     data:
-#       image: velero/velero-restic-restore-helper:v1.3.1
+#       image: velero/velero-restic-restore-helper:v1.6.0
 configMaps: {}
 
 ##

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -36,7 +36,7 @@ podAnnotations: {}
 podLabels: {}
 
 # Resource requests/limits to specify for the Velero deployment.
-# https://velero.io/docs/main/customize-installation/#customize-resource-requests-and-limits
+# https://velero.io/docs/v1.6/customize-installation/#customize-resource-requests-and-limits
 resources:
   requests:
     cpu: 500m
@@ -119,7 +119,7 @@ configuration:
   provider:
 
   # Parameters for the `default` BackupStorageLocation. See
-  # https://velero.io/docs/main/api-types/backupstoragelocation/
+  # https://velero.io/docs/v1.6/api-types/backupstoragelocation/
   backupStorageLocation:
     # name is the name of the backup storage location where backups should be stored. If a name is not provided,
     # a backup storage location will be created with the name "default". Optional.
@@ -150,7 +150,7 @@ configuration:
     #  serviceAccount:
 
   # Parameters for the `default` VolumeSnapshotLocation. See
-  # https://velero.io/docs/main/api-types/volumesnapshotlocation/
+  # https://velero.io/docs/v1.6/api-types/volumesnapshotlocation/
   volumeSnapshotLocation:
     # name is the name of the volume snapshot location where snapshots are being taken. Required.
     name:
@@ -275,7 +275,7 @@ restic:
   # Pod priority class name to use for the Restic daemonset. Optional.
   priorityClassName: ""
   # Resource requests/limits to specify for the Restic daemonset deployment. Optional.
-  # https://velero.io/docs/main/customize-installation/#customize-resource-requests-and-limits
+  # https://velero.io/docs/v1.6/customize-installation/#customize-resource-requests-and-limits
   resources:
     requests:
       cpu: 500m


### PR DESCRIPTION
#### Special notes for your reviewer:

Run a _Job_ to apply the CRDs against the Velero container image the user specify.
- On `helm install`, the user might _change_ the velero container image tag, we should update the CRDs to make sure they match against the Velero server.
-  On `helm upgrade`, the velero container image might _upgrade_ to a newer version, we should update the CRDs to make sure they match against the Velero server.
- On `helm rollback`, the velero container image might _downgrade_ to an old version, we should update the CRDs to make sure they match against the Velero server.

Then, we configured these CRs to the cluster (after the applying the CRDs finished):
1. backupstoragelocations.yaml
1. schedules.yaml
1. volumesnapshotlocation.yaml

We _must_ make sure the install/upgrade/rollback CRDs job finished then apply these CRs manifest.
According to https://helm.sh/docs/topics/charts_hooks/, we add the `post-install`, `post-upgrade`, and `post-rollback` to these CRs to make sure that the CRs will wait for the install/upgrade/rollback CRDs job runs to completion and then, apply the CRs manifest.

BTW, since velero CLI installed CRDs are with labels `component: velero`. To make sure both CLI installed Velero _or_ helm installed Velero having the same labels, we add label `component: velero` to the CRDs.

fixes #197

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
