### PR TITLE
[velero] Make upgradeCrds an optional hook

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.6.0
 description: A Helm chart for velero
 name: velero
-version: 2.19.2
+version: 2.19.3
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.upgradeCrdsJob.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -17,6 +18,12 @@ spec:
     metadata:
       name: velero-upgrade-crds
     spec:
+      {{- if .Values.image.imagePullSecrets }}
+        imagePullSecrets:
+        {{- range .Values.image.imagePullSecrets }}
+          - name: {{ . }}
+        {{- end }}
+      {{- end }}
       serviceAccountName: {{ include "velero.serverServiceAccount" . }}
       initContainers:
         - name: velero
@@ -35,8 +42,12 @@ spec:
               name: crds
       containers:
         - name: kubectl
-          image: docker.io/bitnami/kubectl:1.14.3
-          imagePullPolicy: IfNotPresent
+      {{- if .Values.upgradeCrdsJob.kubectlImage.digest }}
+          image: "{{ .Values.upgradeCrdsJob.kubectlImage.repository }}@{{ .Values.upgradeCrdsJob.kubectlImage.digest }}"
+      {{- else }}
+          image: "{{ .Values.upgradeCrdsJob.kubectlImage.repository }}:{{ .Values.upgradeCrdsJob.kubectlImage.tag }}"
+      {{- end }}
+          imagePullPolicy: {{ .Values.upgradeCrdsJob.kubectlImage.pullPolicy }}
           command:
             - /bin/sh
             - -c
@@ -48,3 +59,4 @@ spec:
         - name: crds
           emptyDir: {}
       restartPolicy: OnFailure
+{{- end }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -213,6 +213,25 @@ configuration:
 
 
 ##
+## Settings for the CRD upgrade hook
+##
+upgradeCrdsJob:
+  # Whether to enable the CRD upgrade job on install, upgrade or rollback
+  enabled: true
+  # The upgrade job needs kubectl to apply the rendered manifests.
+  # This options lets you specify a kubectl container image to apply the rendered manifests.
+  kubectlImage:
+    repository: docker.io/bitnami/kubectl
+    tag: 1.14.3
+    # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38. If used, it will
+    # take precedence over the image.tag.
+    # digest:
+    pullPolicy: IfNotPresent
+##
+## End of the CRD upgrade hook section.
+##
+
+##
 ## Settings for additional Velero resources.
 ##
 


### PR DESCRIPTION
The upgrade CRD hook is not always necessary (especially when using helms' `skip-crds` config option and deploying the crds manually).

In addition to that the upgrade hook was pretty limited in its configuration, so i decided to also
- add support for `imagePullSecrets` (which COULD be obtained through the service account, but since the deployment also supports it, I decided to add it to the job as well)
- add the ability to override the kubectl image (especially necessary in on-prem environments or if you want to use a newer kubectl version, closer to the version running on your cluster)

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
