### PR TITLE
[velero] Adds node constraints to job definition

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.6.0
 description: A Helm chart for velero
 name: velero
-version: 2.20.0
+version: 2.21.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/cleanup-crds.yaml
+++ b/charts/velero/templates/cleanup-crds.yaml
@@ -54,4 +54,16 @@ spec:
               kubectl delete podvolumerestore --all;
               kubectl delete crd -l app.kubernetes.io/name=velero;
       restartPolicy: OnFailure
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/velero/templates/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds.yaml
@@ -67,4 +67,16 @@ spec:
         - name: crds
           emptyDir: {}
       restartPolicy: OnFailure
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: WisdomWolf <wisdomwolf@gmail.com>

#### Special notes for your reviewer:
As someone who runs a mixed architecture cluster with both ARM and AMD64 devices, I was initially unable to deploy Velero using the helm chart because the Jobs were scheduled to ARM devices which failed.  I added the nodeSelector, tolerations, and affinity sections to the job templates with the same values used in the deployment template.  I confirmed that it worked as expected by deploying the chart locally to my cluster.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
