### PR TITLE
[velero] remove all default value fields

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.6.0
 description: A Helm chart for velero
 name: velero
-version: 2.20.0
+version: 2.20.1
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/crds/backups.yaml
+++ b/charts/velero/crds/backups.yaml
@@ -17,7 +17,6 @@ spec:
     listKind: BackupList
     plural: backups
     singular: backup
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -48,14 +47,12 @@ spec:
                 not included in the backup.
               items:
                 type: string
-              nullable: true
               type: array
             excludedResources:
               description: ExcludedResources is a slice of resource names that are
                 not included in the backup.
               items:
                 type: string
-              nullable: true
               type: array
             hooks:
               description: Hooks represent custom behaviors that should be executed
@@ -74,14 +71,12 @@ spec:
                           which this hook spec does not apply.
                         items:
                           type: string
-                        nullable: true
                         type: array
                       excludedResources:
                         description: ExcludedResources specifies the resources to
                           which this hook spec does not apply.
                         items:
                           type: string
-                        nullable: true
                         type: array
                       includedNamespaces:
                         description: IncludedNamespaces specifies the namespaces to
@@ -89,7 +84,6 @@ spec:
                           namespaces.
                         items:
                           type: string
-                        nullable: true
                         type: array
                       includedResources:
                         description: IncludedResources specifies the resources to
@@ -97,12 +91,10 @@ spec:
                           resources.
                         items:
                           type: string
-                        nullable: true
                         type: array
                       labelSelector:
                         description: LabelSelector, if specified, filters the resources
                           to which this hook spec applies.
-                        nullable: true
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector
@@ -238,33 +230,28 @@ spec:
                     required:
                     - name
                     type: object
-                  nullable: true
                   type: array
               type: object
             includeClusterResources:
               description: IncludeClusterResources specifies whether cluster-scoped
                 resources should be included for consideration in the backup.
-              nullable: true
               type: boolean
             includedNamespaces:
               description: IncludedNamespaces is a slice of namespace names to include
                 objects from. If empty, all namespaces are included.
               items:
                 type: string
-              nullable: true
               type: array
             includedResources:
               description: IncludedResources is a slice of resource names to include
                 in the backup. If empty, all resources are included.
               items:
                 type: string
-              nullable: true
               type: array
             labelSelector:
               description: LabelSelector is a metav1.LabelSelector to filter with
                 when adding individual objects to the backup. If empty or nil, all
                 objects are included. Optional.
-              nullable: true
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.
@@ -313,12 +300,10 @@ spec:
                 of specific Kind. The map key is the Kind name and value is a list
                 of resource names separated by commas. Each resource name has format
                 "namespace/resourcename".  For cluster resources, simply use "resourcename".
-              nullable: true
               type: object
             snapshotVolumes:
               description: SnapshotVolumes specifies whether to take cloud snapshots
                 of any PV's referenced in the set of objects included in the Backup.
-              nullable: true
               type: boolean
             storageLocation:
               description: StorageLocation is a string containing the name of a BackupStorageLocation
@@ -344,7 +329,6 @@ spec:
                 is recorded before uploading the backup object. The server's time
                 is used for CompletionTimestamps
               format: date-time
-              nullable: true
               type: string
             errors:
               description: Errors is a count of all error messages that were generated
@@ -354,7 +338,6 @@ spec:
             expiration:
               description: Expiration is when this Backup is eligible for garbage-collection.
               format: date-time
-              nullable: true
               type: string
             formatVersion:
               description: FormatVersion is the backup format version, including major,
@@ -375,7 +358,6 @@ spec:
               description: Progress contains information about the backup's execution
                 progress. Note that this information is best-effort only -- if Velero
                 fails to update it during a backup for any reason, it may be inaccurate/stale.
-              nullable: true
               properties:
                 itemsBackedUp:
                   description: ItemsBackedUp is the number of items that have actually
@@ -394,14 +376,12 @@ spec:
                 from CreationTimestamp, since that value changes on restores. The
                 server's time is used for StartTimestamps
               format: date-time
-              nullable: true
               type: string
             validationErrors:
               description: ValidationErrors is a slice of all validation errors (if
                 applicable).
               items:
                 type: string
-              nullable: true
               type: array
             version:
               description: 'Version is the backup format major version. Deprecated:

--- a/charts/velero/crds/backupstoragelocations.yaml
+++ b/charts/velero/crds/backupstoragelocations.yaml
@@ -36,7 +36,6 @@ spec:
     shortNames:
     - bsl
     singular: backupstoragelocation
-  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -71,7 +70,6 @@ spec:
             backupSyncPeriod:
               description: BackupSyncPeriod defines how frequently to sync backup
                 API objects from object storage. A value of 0 disables sync.
-              nullable: true
               type: string
             config:
               additionalProperties:
@@ -125,7 +123,6 @@ spec:
             validationFrequency:
               description: ValidationFrequency defines how frequently to validate
                 the corresponding object storage. A value of 0 disables validation.
-              nullable: true
               type: string
           required:
           - objectStorage
@@ -153,13 +150,11 @@ spec:
               description: LastSyncedTime is the last time the contents of the location
                 were synced into the cluster.
               format: date-time
-              nullable: true
               type: string
             lastValidationTime:
               description: LastValidationTime is the last time the backup store location
                 was validated the cluster.
               format: date-time
-              nullable: true
               type: string
             phase:
               description: Phase is the current state of the BackupStorageLocation.

--- a/charts/velero/crds/deletebackuprequests.yaml
+++ b/charts/velero/crds/deletebackuprequests.yaml
@@ -17,7 +17,6 @@ spec:
     listKind: DeleteBackupRequestList
     plural: deletebackuprequests
     singular: deletebackuprequest
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -52,7 +51,6 @@ spec:
                 the deletion process.
               items:
                 type: string
-              nullable: true
               type: array
             phase:
               description: Phase is the current state of the DeleteBackupRequest.

--- a/charts/velero/crds/downloadrequests.yaml
+++ b/charts/velero/crds/downloadrequests.yaml
@@ -17,7 +17,6 @@ spec:
     listKind: DownloadRequestList
     plural: downloadrequests
     singular: downloadrequest
-  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -76,7 +75,6 @@ spec:
               description: Expiration is when this DownloadRequest expires and can
                 be deleted by the system.
               format: date-time
-              nullable: true
               type: string
             phase:
               description: Phase is the current state of the DownloadRequest.

--- a/charts/velero/crds/podvolumebackups.yaml
+++ b/charts/velero/crds/podvolumebackups.yaml
@@ -17,7 +17,6 @@ spec:
     listKind: PodVolumeBackupList
     plural: podvolumebackups
     singular: podvolumebackup
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -110,7 +109,6 @@ spec:
                 is recorded before uploading the backup object. The server's time
                 is used for CompletionTimestamps
               format: date-time
-              nullable: true
               type: string
             message:
               description: Message is a message about the pod volume backup's status.
@@ -148,7 +146,6 @@ spec:
                 from CreationTimestamp, since that value changes on restores. The
                 server's time is used for StartTimestamps
               format: date-time
-              nullable: true
               type: string
           type: object
       type: object

--- a/charts/velero/crds/podvolumerestores.yaml
+++ b/charts/velero/crds/podvolumerestores.yaml
@@ -17,7 +17,6 @@ spec:
     listKind: PodVolumeRestoreList
     plural: podvolumerestores
     singular: podvolumerestore
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -102,7 +101,6 @@ spec:
                 Completion time is recorded even on failed restores. The server's
                 time is used for CompletionTimestamps
               format: date-time
-              nullable: true
               type: string
             message:
               description: Message is a message about the pod volume restore's status.
@@ -131,7 +129,6 @@ spec:
               description: StartTimestamp records the time a restore was started.
                 The server's time is used for StartTimestamps
               format: date-time
-              nullable: true
               type: string
           type: object
       type: object

--- a/charts/velero/crds/resticrepositories.yaml
+++ b/charts/velero/crds/resticrepositories.yaml
@@ -17,7 +17,6 @@ spec:
     listKind: ResticRepositoryList
     plural: resticrepositories
     singular: resticrepository
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -65,7 +64,6 @@ spec:
             lastMaintenanceTime:
               description: LastMaintenanceTime is the last time maintenance was run.
               format: date-time
-              nullable: true
               type: string
             message:
               description: Message is a message about the current status of the ResticRepository.

--- a/charts/velero/crds/restores.yaml
+++ b/charts/velero/crds/restores.yaml
@@ -15,7 +15,6 @@ spec:
     listKind: RestoreList
     plural: restores
     singular: restore
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -46,14 +45,12 @@ spec:
                 not included in the restore.
               items:
                 type: string
-              nullable: true
               type: array
             excludedResources:
               description: ExcludedResources is a slice of resource names that are
                 not included in the restore.
               items:
                 type: string
-              nullable: true
               type: array
             hooks:
               description: Hooks represent custom behaviors that should be executed
@@ -70,14 +67,12 @@ spec:
                           which this hook spec does not apply.
                         items:
                           type: string
-                        nullable: true
                         type: array
                       excludedResources:
                         description: ExcludedResources specifies the resources to
                           which this hook spec does not apply.
                         items:
                           type: string
-                        nullable: true
                         type: array
                       includedNamespaces:
                         description: IncludedNamespaces specifies the namespaces to
@@ -85,7 +80,6 @@ spec:
                           namespaces.
                         items:
                           type: string
-                        nullable: true
                         type: array
                       includedResources:
                         description: IncludedResources specifies the resources to
@@ -93,12 +87,10 @@ spec:
                           resources.
                         items:
                           type: string
-                        nullable: true
                         type: array
                       labelSelector:
                         description: LabelSelector, if specified, filters the resources
                           to which this hook spec applies.
-                        nullable: true
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector
@@ -1509,27 +1501,23 @@ spec:
               description: IncludeClusterResources specifies whether cluster-scoped
                 resources should be included for consideration in the restore. If
                 null, defaults to true.
-              nullable: true
               type: boolean
             includedNamespaces:
               description: IncludedNamespaces is a slice of namespace names to include
                 objects from. If empty, all namespaces are included.
               items:
                 type: string
-              nullable: true
               type: array
             includedResources:
               description: IncludedResources is a slice of resource names to include
                 in the restore. If empty, all resources in the backup are included.
               items:
                 type: string
-              nullable: true
               type: array
             labelSelector:
               description: LabelSelector is a metav1.LabelSelector to filter with
                 when restoring individual objects from the backup. If empty or nil,
                 all objects are included. Optional.
-              nullable: true
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.
@@ -1581,12 +1569,10 @@ spec:
             preserveNodePorts:
               description: PreserveNodePorts specifies whether to restore old nodePorts
                 from backup.
-              nullable: true
               type: boolean
             restorePVs:
               description: RestorePVs specifies whether to restore all included PVs
                 from snapshot (via the cloudprovider).
-              nullable: true
               type: boolean
             scheduleName:
               description: ScheduleName is the unique name of the Velero schedule
@@ -1604,7 +1590,6 @@ spec:
                 was completed. Completion time is recorded even on failed restore.
                 The server's time is used for StartTimestamps
               format: date-time
-              nullable: true
               type: string
             errors:
               description: Errors is a count of all error messages that were generated
@@ -1629,7 +1614,6 @@ spec:
               description: Progress contains information about the restore's execution
                 progress. Note that this information is best-effort only -- if Velero
                 fails to update it during a restore for any reason, it may be inaccurate/stale.
-              nullable: true
               properties:
                 itemsRestored:
                   description: ItemsRestored is the number of items that have actually
@@ -1645,14 +1629,12 @@ spec:
               description: StartTimestamp records the time the restore operation was
                 started. The server's time is used for StartTimestamps
               format: date-time
-              nullable: true
               type: string
             validationErrors:
               description: ValidationErrors is a slice of all validation errors (if
                 applicable)
               items:
                 type: string
-              nullable: true
               type: array
             warnings:
               description: Warnings is a count of all warning messages that were generated

--- a/charts/velero/crds/schedules.yaml
+++ b/charts/velero/crds/schedules.yaml
@@ -17,7 +17,6 @@ spec:
     listKind: ScheduleList
     plural: schedules
     singular: schedule
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -56,14 +55,12 @@ spec:
                     are not included in the backup.
                   items:
                     type: string
-                  nullable: true
                   type: array
                 excludedResources:
                   description: ExcludedResources is a slice of resource names that
                     are not included in the backup.
                   items:
                     type: string
-                  nullable: true
                   type: array
                 hooks:
                   description: Hooks represent custom behaviors that should be executed
@@ -82,14 +79,12 @@ spec:
                               to which this hook spec does not apply.
                             items:
                               type: string
-                            nullable: true
                             type: array
                           excludedResources:
                             description: ExcludedResources specifies the resources
                               to which this hook spec does not apply.
                             items:
                               type: string
-                            nullable: true
                             type: array
                           includedNamespaces:
                             description: IncludedNamespaces specifies the namespaces
@@ -97,7 +92,6 @@ spec:
                               to all namespaces.
                             items:
                               type: string
-                            nullable: true
                             type: array
                           includedResources:
                             description: IncludedResources specifies the resources
@@ -105,12 +99,10 @@ spec:
                               to all resources.
                             items:
                               type: string
-                            nullable: true
                             type: array
                           labelSelector:
                             description: LabelSelector, if specified, filters the
                               resources to which this hook spec applies.
-                            nullable: true
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
@@ -252,33 +244,28 @@ spec:
                         required:
                         - name
                         type: object
-                      nullable: true
                       type: array
                   type: object
                 includeClusterResources:
                   description: IncludeClusterResources specifies whether cluster-scoped
                     resources should be included for consideration in the backup.
-                  nullable: true
                   type: boolean
                 includedNamespaces:
                   description: IncludedNamespaces is a slice of namespace names to
                     include objects from. If empty, all namespaces are included.
                   items:
                     type: string
-                  nullable: true
                   type: array
                 includedResources:
                   description: IncludedResources is a slice of resource names to include
                     in the backup. If empty, all resources are included.
                   items:
                     type: string
-                  nullable: true
                   type: array
                 labelSelector:
                   description: LabelSelector is a metav1.LabelSelector to filter with
                     when adding individual objects to the backup. If empty or nil,
                     all objects are included. Optional.
-                  nullable: true
                   properties:
                     matchExpressions:
                       description: matchExpressions is a list of label selector requirements.
@@ -329,12 +316,10 @@ spec:
                     list of resource names separated by commas. Each resource name
                     has format "namespace/resourcename".  For cluster resources, simply
                     use "resourcename".
-                  nullable: true
                   type: object
                 snapshotVolumes:
                   description: SnapshotVolumes specifies whether to take cloud snapshots
                     of any PV's referenced in the set of objects included in the Backup.
-                  nullable: true
                   type: boolean
                 storageLocation:
                   description: StorageLocation is a string containing the name of
@@ -354,7 +339,6 @@ spec:
             useOwnerReferencesInBackup:
               description: UseOwnerReferencesBackup specifies whether to use OwnerReferences
                 on backups created by this Schedule.
-              nullable: true
               type: boolean
           required:
           - schedule
@@ -367,7 +351,6 @@ spec:
               description: LastBackup is the last time a Backup was run for this Schedule
                 schedule
               format: date-time
-              nullable: true
               type: string
             phase:
               description: Phase is the current phase of the Schedule

--- a/charts/velero/crds/serverstatusrequests.yaml
+++ b/charts/velero/crds/serverstatusrequests.yaml
@@ -19,7 +19,6 @@ spec:
     shortNames:
     - ssr
     singular: serverstatusrequest
-  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -66,13 +65,11 @@ spec:
                 - kind
                 - name
                 type: object
-              nullable: true
               type: array
             processedTimestamp:
               description: ProcessedTimestamp is when the ServerStatusRequest was
                 processed by the ServerStatusRequestController.
               format: date-time
-              nullable: true
               type: string
             serverVersion:
               description: ServerVersion is the Velero server version.

--- a/charts/velero/crds/volumesnapshotlocations.yaml
+++ b/charts/velero/crds/volumesnapshotlocations.yaml
@@ -17,7 +17,6 @@ spec:
     listKind: VolumeSnapshotLocationList
     plural: volumesnapshotlocations
     singular: volumesnapshotlocation
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:


### PR DESCRIPTION
this commit removes all `nullable: true` and `preserveUnknownFields:
false` mentions. 

#### Special notes for your reviewer:

These are default and not visible when dumping the
resource from the Kubernetes API. That causes ArgoCD to always detect
a diff. The resources themselves are unchanged.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
