### PR TITLE
[velero] set useOwnerReferencesInBackup to schedule spec if it's set on values

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.6.0
 description: A Helm chart for velero
 name: velero
-version: 2.22.0
+version: 2.22.1
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/schedule.yaml
+++ b/charts/velero/templates/schedule.yaml
@@ -18,6 +18,9 @@ metadata:
       {{- toYaml $schedule.labels | nindent 4 }}
     {{- end }}
 spec:
+{{- if $schedule.useOwnerReferencesInBackup }}
+  useOwnerReferencesInBackup: {{ $schedule.useOwnerReferencesInBackup }}
+{{- end }}
   schedule: {{ $schedule.schedule | quote }}
 {{- with $schedule.template }}
   template:

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -356,6 +356,7 @@ restic:
 #     annotations:
 #       myenv: foo
 #     schedule: "0 0 * * *"
+#     useOwnerReferencesInBackup: true
 #     template:
 #       ttl: "240h"
 #       includedNamespaces:


### PR DESCRIPTION
#### Special notes for your reviewer:
Hi (Olá) guys, since Velero was released in version 1.6.0, we would like to use the field `useOwnerReferencesInBackup`, to avoid Argo CD issues in our deploying process.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)

Signed-off-by: Caio Almeida <caio.almeida@gympass.com>