### PR TITLE
[velero] allow disabling schedule in value overrides

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -19,7 +19,7 @@ jobs:
           command: lint
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0
+        uses: helm/kind-action@v1.2.0
         # Only build a kind cluster if there are chart changes to test.
         if: steps.lint.outputs.changed == 'true'
 

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.6.1
 description: A Helm chart for velero
 name: velero
-version: 2.23.2
+version: 2.23.3
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/schedule.yaml
+++ b/charts/velero/templates/schedule.yaml
@@ -1,4 +1,5 @@
 {{- range $scheduleName, $schedule := .Values.schedules }}
+{{- if (not $schedule.disabled) }}
 apiVersion: velero.io/v1
 kind: Schedule
 metadata:
@@ -27,4 +28,5 @@ spec:
     {{- toYaml . | nindent 4 }}
 {{- end }}
 ---
+{{- end }}
 {{- end }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -351,6 +351,7 @@ restic:
 # Eg:
 # schedules:
 #   mybackup:
+#     disabled: false
 #     labels:
 #       myenv: foo
 #     annotations:


### PR DESCRIPTION
#### Special notes for your reviewer:

In multi-layer environment where several values files are applied, it is very useful to allow disabling a schedule that is defined in a common values file.

Reopens https://github.com/vmware-tanzu/helm-charts/pull/208

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
