### PR TITLE
[velero] Bump CI helm/kind-action version v1.2.0

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -19,7 +19,7 @@ jobs:
           command: lint
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0
+        uses: helm/kind-action@v1.2.0
         # Only build a kind cluster if there are chart changes to test.
         if: steps.lint.outputs.changed == 'true'
 


### PR DESCRIPTION
#### Special notes for your reviewer:

fix CI failure on the node is not ready
> Warning FailedScheduling 45s (x5 over 5m) default-scheduler 0/1 nodes are available: 1 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate.



#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] ~Chart Version bumped~
- [x] ~Variables are documented in the values.yaml or README.md~
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
