### PR TITLE
[velero] Use Kubernetes version for kubectl version/tag

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.6.3
 description: A Helm chart for velero
 name: velero
-version: 2.23.6
+version: 2.23.7
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds.yaml
@@ -52,8 +52,10 @@ spec:
         - name: kubectl
           {{- if .Values.kubectl.image.digest }}
           image: "{{ .Values.kubectl.image.repository }}@{{ .Values.kubectl.image.digest }}"
-          {{- else }}
+          {{- else if .Values.kubectl.image.tag }}
           image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
+          {{- else }}
+          image: "{{ .Values.kubectl.image.repository }}:{{ trimPrefix "v" .Capabilities.KubeVersion.Version }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -117,10 +117,11 @@ metrics:
 kubectl:
   image:
     repository: docker.io/bitnami/kubectl
-    tag: 1.16.15
     # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
     # If used, it will take precedence over the kubectl.image.tag.
     # digest:
+    # kubectl image tag. If used, it will take precedence over the cluster Kubernetes version.
+    # tag: 1.16.15
   # Annotations to set for the upgrade/cleanup job. Optional.
   annotations: {}
   # Labels to set for the upgrade/cleanup job. Optional.


### PR DESCRIPTION
#### Special notes for your reviewer:

- The kubectl image tag ordering is `digest -> tag -> cluster Kubernetes version`
- Comment out the `.Values.kubectl.image.tag`, which means that by default the kubectl image tag would be cluster Kubernetes version.

fixes #293

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] ~Variables are documented in the values.yaml or README.md~
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
