### PR TITLE
[velero] Use major.minor version of kubectl image

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.6.3
 description: A Helm chart for velero
 name: velero
-version: 2.23.7
+version: 2.23.8
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds.yaml
@@ -55,7 +55,7 @@ spec:
           {{- else if .Values.kubectl.image.tag }}
           image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
           {{- else }}
-          image: "{{ .Values.kubectl.image.repository }}:{{ trimPrefix "v" .Capabilities.KubeVersion.Version }}"
+          image: "{{ .Values.kubectl.image.repository }}:{{ .Capabilities.KubeVersion.Major }}.{{ .Capabilities.KubeVersion.Minor }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:


### PR DESCRIPTION
#### Special notes for your reviewer:

fixes #302

The Kubernetes server version might contain released versions, for example, `1.21.4-gke.301`.
Use the `KubeVersion.Version` would result in the corresponding kubectl image tag can't be pulled.
Change to use `major.minor` version to pull the kubectl image tag.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] ~Variables are documented in the values.yaml or README.md~
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
