### PR TITLE
[velero] Allow to define resource requests/limits for the containers in the upgrade/cleanup job

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.6.3
 description: A Helm chart for velero
 name: velero
-version: 2.23.8
+version: 2.23.9
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/cleanup-crds.yaml
+++ b/charts/velero/templates/cleanup-crds.yaml
@@ -53,6 +53,10 @@ spec:
               kubectl delete volumesnapshotlocation --all;
               kubectl delete podvolumerestore --all;
               kubectl delete crd -l app.kubernetes.io/name=velero;
+          {{- with .Values.kubectl.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       restartPolicy: OnFailure
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/velero/templates/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds.yaml
@@ -45,6 +45,10 @@ spec:
             - /bin/sh
             - -c
             - /velero install --crds-only --dry-run -o yaml > /tmp/crds.yaml
+          {{- with .Values.kubectl.initResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /tmp
               name: crds
@@ -62,6 +66,10 @@ spec:
             - /bin/sh
             - -c
             - kubectl apply -f /tmp/crds.yaml
+          {{- with .Values.kubectl.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /tmp
               name: crds

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -122,6 +122,10 @@ kubectl:
     # digest:
     # kubectl image tag. If used, it will take precedence over the cluster Kubernetes version.
     # tag: 1.16.15
+  # Resource requests/limits to specify for the upgrade/cleanup job. Optional
+  resources: {}
+  # Resource requests/limits to specify for the initContainer in the upgrade/cleanup job. Optional
+  initResources: {}
   # Annotations to set for the upgrade/cleanup job. Optional.
   annotations: {}
   # Labels to set for the upgrade/cleanup job. Optional.


### PR DESCRIPTION
This PR allows to define resource requests and limits for the containers in the upgrade and cleanup jobs.
This is necessary in kubernetes clusters where an admission controller prevents the creation of pods without proper resource requests and limits.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
