### PR TITLE
[velero] Fix GKE/EKS with wrong kubectl image tag

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.6.3
 description: A Helm chart for velero
 name: velero
-version: 2.23.9
+version: 2.23.10
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/_helpers.tpl
+++ b/charts/velero/templates/_helpers.tpl
@@ -110,3 +110,15 @@ Create the volume snapshot location provider
 {{ default .provider .volumeSnapshotLocation.provider }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Kubernetes version
+Built-in object .Capabilities.KubeVersion.Minor can provide non-number output
+For examples:
+- on GKE it returns "18+" instead of "18"
+- on EKS it returns "20+" instead of "20"
+*/}}
+{{- define "chart.KubernetesVersion" -}}
+{{- $minorVersion := .Capabilities.KubeVersion.Minor | regexFind "[0-9]+" -}}
+{{- printf "%s.%s" .Capabilities.KubeVersion.Major $minorVersion -}}
+{{- end -}}

--- a/charts/velero/templates/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds.yaml
@@ -59,7 +59,7 @@ spec:
           {{- else if .Values.kubectl.image.tag }}
           image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
           {{- else }}
-          image: "{{ .Values.kubectl.image.repository }}:{{ .Capabilities.KubeVersion.Major }}.{{ .Capabilities.KubeVersion.Minor }}"
+          image: "{{ .Values.kubectl.image.repository }}:{{ template "chart.KubernetesVersion" . }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:


### PR DESCRIPTION
#### Special notes for your reviewer:

Built-in object `.Capabilities.KubeVersion.Minor` can provide non-number output
For examples:
- on GKE it returns "18+" instead of "18"
- on EKS it returns "20+" instead of "20"

Ref to https://github.com/artifacthub/hub/blob/db0fa6d/charts/artifact-hub/templates/_helpers.tpl#L54-L62

fixes #303

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] ~Variables are documented in the values.yaml or README.md~
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
