### PR TITLE
[velero] fix extraEnvVars support

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.6.3
 description: A Helm chart for velero
 name: velero
-version: 2.23.10
+version: 2.23.11
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -174,7 +174,7 @@ spec:
             - name: {{ default "none" $key }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "velero.fullname" $ }}
+                  name: {{ include "velero.secretName" $ }}
                   key: {{ default "none" $key }}
           {{- end }}
           {{- end }}

--- a/charts/velero/templates/restic-daemonset.yaml
+++ b/charts/velero/templates/restic-daemonset.yaml
@@ -146,7 +146,7 @@ spec:
             - name: {{ default "none" $key }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "velero.fullname" $ }}
+                  name: {{ include "velero.secretName" $ }}
                   key: {{ default "none" $key }}
           {{- end }}
           {{- end }}


### PR DESCRIPTION
Fixes the mistake I introduced in #99, see https://github.com/vmware-tanzu/helm-charts/pull/99#issuecomment-918133171.
All credits to @mshivanna.

#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
