### PR TITLE
[velero] Invalid `initContainers[0].imagePullPolicy`

### DIFF
--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -53,7 +53,6 @@ dnsPolicy: ClusterFirst
 initContainers: []
   # - name: velero-plugin-for-aws
   #   image: velero/velero-plugin-for-aws:v1.2.0
-  #   imagePullPolicy: IfNotPresent
   #   volumeMounts:
   #     - mountPath: /target
   #       name: plugins


### PR DESCRIPTION
#### Special notes for your reviewer:

Presumably this was meant to be `pullPolicy`. But if you actually try to specify something, Helm fails:

```
Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.initContainers[0]): unknown field "pullPolicy" in io.k8s.api.core.v1.Container
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[velero]`)
