### PR TITLE
[velero] Add defaultResticPruneFrequency option to helm chart

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.7.0
 description: A Helm chart for velero
 name: velero
-version: 2.26.4
+version: 2.26.5
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -99,6 +99,9 @@ spec:
             {{- if .defaultVolumesToRestic }}
             - --default-volumes-to-restic
             {{- end }}
+            {{- with .defaultResticMaintenanceFrequency }}
+            - --default-restic-prune-frequency={{ . }}
+            {{- end }}
             {{- with .clientQPS }}
             - --client-qps={{ . }}
             {{- end }}

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -99,7 +99,7 @@ spec:
             {{- if .defaultVolumesToRestic }}
             - --default-volumes-to-restic
             {{- end }}
-            {{- with .defaultResticMaintenanceFrequency }}
+            {{- with .defaultResticPruneFrequency }}
             - --default-restic-prune-frequency={{ . }}
             {{- end }}
             {{- with .clientQPS }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -246,7 +246,7 @@ configuration:
   defaultVolumesToRestic:
 
   # How often 'restic prune' is run for restic repositories by default. Default: 168h. Optional.
-  defaultResticMaintenanceFrequency: 24h
+  defaultResticMaintenanceFrequency:
 
 ##
 ## End of backup/snapshot location settings.

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -245,6 +245,9 @@ configuration:
   # Set true for backup all pod volumes without having to apply annotation on the pod when used restic Default: false. Other option: false.
   defaultVolumesToRestic:
 
+  # How often 'restic prune' is run for restic repositories by default. Default: 168h. Optional.
+  defaultResticMaintenanceFrequency: 24h
+
 ##
 ## End of backup/snapshot location settings.
 ##

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -246,7 +246,7 @@ configuration:
   defaultVolumesToRestic:
 
   # How often 'restic prune' is run for restic repositories by default. Default: 168h. Optional.
-  defaultResticMaintenanceFrequency:
+  defaultResticPruneFrequency:
 
 ##
 ## End of backup/snapshot location settings.


### PR DESCRIPTION
#### Special notes for your reviewer:
Closes #321
Tested locally with success

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the values.yaml or README.md
- [X] Title of the PR starts with chart name (e.g. `[velero]`)
