### PR TITLE
[velero] allow setting initContainers as a template

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.7.0
 description: A Helm chart for velero
 name: velero
-version: 2.26.5
+version: 2.27.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -184,7 +184,11 @@ spec:
       dnsPolicy: {{ .Values.dnsPolicy }}
 {{- if .Values.initContainers }}
       initContainers:
+        {{- if eq (typeOf .Values.initContainers) "string" }}
+        {{- tpl .Values.initContainers . | nindent 8 }}
+        {{- else }}
         {{- toYaml .Values.initContainers | nindent 8 }}
+        {{- end }}
 {{- end }}
       volumes:
         {{- if .Values.credentials.useSecret }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -50,6 +50,7 @@ resources:
 dnsPolicy: ClusterFirst
 
 # Init containers to add to the Velero deployment's pod spec. At least one plugin provider image is required.
+# If the value is a string then it is evaluated as a template.
 initContainers: []
   # - name: velero-plugin-for-csi
   #   image: velero/velero-plugin-for-csi:v0.2.0

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -51,7 +51,7 @@ dnsPolicy: ClusterFirst
 
 # Init containers to add to the Velero deployment's pod spec. At least one plugin provider image is required.
 # If the value is a string then it is evaluated as a template.
-initContainers: []
+initContainers:
   # - name: velero-plugin-for-csi
   #   image: velero/velero-plugin-for-csi:v0.2.0
   #   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
#### Special notes for your reviewer:

A container is a complex structure that itself is usually templated with numerous references to values and other subtemplates. In the values of velero chart `initContainers` is given as a list which means it can't be overridden partially - the whole definition of the init containers must be copied every time a tiny override is needed.

This change allows setting the value of `initContainers` as a string which in turn causes the chart to render it as a template, e.g.:
```yaml
initContainers: |-
  - name: myplugin
    image: {{ .Values.myplugin.image.repository }}:{{ .Values.myplugin.image.tag }}
    resources:
      {{- .Values.myplugin.resources | toYaml | nindent 6 }}
    ...
myplugin:
  image:
    ...
  resources:
    ...
```
and then the init container itself can be customized conveniently by regular values selectively.

Note: I've pumped the minor version and not the patch version because this introduces a change in the schema of values.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
