### PR TITLE
[velero] fix for failing init-container/crd updates

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.7.1
 description: A Helm chart for velero
 name: velero
-version: 2.27.1
+version: 2.27.2
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds.yaml
@@ -45,6 +45,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /bin/sh
+          args:
             - -c
             - cp `which sh` /tmp && cp `which kubectl` /tmp
           {{- with .Values.kubectl.resources }}


### PR DESCRIPTION
fix for failing init-container/crd updates

Since velero image is distroles this helmchart uses /tmp volume to host required binaries (sh binary, etc). To populate /tmp volume with relevant binaries kubectl image contents are used: https://github.com/vmware-tanzu/helm-charts/blob/ab1c80e2301d9eb9b07fca399e02e8022612a59b/charts/velero/templates/upgrade-crds.yaml#L46-L50.
This command is failing as it misses args node. It translates in native docker to:
`docker --entrypoint='sh -c 'cp $(which sh) /tmp && cp $(which kubectl) /tmp'  kubectl`
which in consequence produces empty /tmp directory (failed to start container) later required by:
https://github.com/vmware-tanzu/helm-charts/blob/ab1c80e2301d9eb9b07fca399e02e8022612a59b/charts/velero/templates/upgrade-crds.yaml#L66-L70

This leads to bootloop on fresh installations as stateful /tmp volume is not populated.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
