### PR TITLE
[velero] Added ability to deploy extra K8s manifests

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.7.1
 description: A Helm chart for velero
 name: velero
-version: 2.27.4
+version: 2.28.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/extra-manifests.yaml
+++ b/charts/velero/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -98,6 +98,32 @@ extraVolumes: []
 # Extra volumeMounts for the Velero deployment. Optional.
 extraVolumeMounts: []
 
+# Extra K8s manifests to deploy
+extraObjects: []
+  # - apiVersion: secrets-store.csi.x-k8s.io/v1
+  #   kind: SecretProviderClass
+  #   metadata:
+  #     name: velero-secrets-store
+  #   spec:
+  #     provider: aws
+  #     parameters:
+  #       objects: |
+  #         - objectName: "velero"
+  #           objectType: "secretsmanager"
+  #           jmesPath:
+  #               - path: "access_key"
+  #                 objectAlias: "access_key"
+  #               - path: "secret_key"
+  #                 objectAlias: "secret_key"
+  #     secretObjects:
+  #       - data:
+  #         - key: access_key
+  #           objectName: client-id
+  #         - key: client-secret
+  #           objectName: client-secret
+  #         secretName: velero-secrets-store
+  #         type: Opaque
+
 # Settings for Velero's prometheus metrics. Enabled by default.
 metrics:
   enabled: true


### PR DESCRIPTION
Signed-off-by: Nick Fisher <nxf5025@gmail.com>

#### Special notes for your reviewer:

This PR adds the ability to pass extra kubernetes manifests. Even though the chart contains the ability to reference an existing secret it does not allow us to create the secret in the first place using one of the standard K8s secret add-ons such as the following:

- https://github.com/external-secrets/kubernetes-external-secrets
- https://github.com/kubernetes-sigs/secrets-store-csi-driver

This PR will also cover use cases such as when a user is using AAD Pod Identity and they need to set AzureIdentity & AzureIdentityBinding for velero to properly work.

A few other examples of this being implemented on other projects with some good discussions:
- https://github.com/grafana/helm-charts/pull/928
- https://github.com/oauth2-proxy/manifests/pull/76
- https://github.com/argoproj/argo-helm/pull/1094

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
