### PR TITLE
[velero] Allow default Resource Quotas & Limits to be overridden with empty values

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.8.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 2.28.0
+version: 2.28.1
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -114,8 +114,8 @@ spec:
           {{- end }}
           resources:
           {{- if .Values.resources }}
-            {{- toYaml . | nindent 12 }}
-          {{ else }}
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- else }}
             requests:
               cpu: 500m
               memory: 128Mi

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -112,9 +112,16 @@ spec:
             - --disable-controllers={{ . }}
             {{- end }}
           {{- end }}
-          {{- with .Values.resources }}
           resources:
+          {{- if .Values.resources }}
             {{- toYaml . | nindent 12 }}
+          {{ else }}
+            requests:
+              cpu: 500m
+              memory: 128Mi
+            limits:
+              cpu: 1000m
+              memory: 512Mi
           {{- end }}
           {{- with .Values.containerSecurityContext }}
           securityContext:

--- a/charts/velero/templates/restic-daemonset.yaml
+++ b/charts/velero/templates/restic-daemonset.yaml
@@ -160,9 +160,9 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
           resources:
-          {{- if .Values.resources }}
-            {{- toYaml . | nindent 12 }}
-          {{ else }}
+          {{- if .Values.restic.resources }}
+            {{- toYaml .Values.restic.resources | nindent 12 }}
+          {{- else }}
             requests:
               cpu: 500m
               memory: 128Mi

--- a/charts/velero/templates/restic-daemonset.yaml
+++ b/charts/velero/templates/restic-daemonset.yaml
@@ -159,9 +159,16 @@ spec:
             {{- with $containerSecurityContext }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- with .Values.restic.resources }}
           resources:
+          {{- if .Values.resources }}
             {{- toYaml . | nindent 12 }}
+          {{ else }}
+            requests:
+              cpu: 500m
+              memory: 128Mi
+            limits:
+              cpu: 1000m
+              memory: 512Mi
           {{- end }}
       {{- with .Values.restic.tolerations }}
       tolerations:

--- a/charts/velero/templates/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds.yaml
@@ -74,9 +74,16 @@ spec:
           args:
             - -c
             - /velero install --crds-only --dry-run -o yaml | /tmp/kubectl apply -f -
-          {{- with .Values.resources }}
           resources:
+          {{- if .Values.resources }}
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+            requests:
+              cpu: 500m
+              memory: 128Mi
+            limits:
+              cpu: 1000m
+              memory: 512Mi
           {{- end }}
           {{- with .Values.containerSecurityContext }}
           securityContext:

--- a/charts/velero/templates/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds.yaml
@@ -76,7 +76,7 @@ spec:
             - /velero install --crds-only --dry-run -o yaml | /tmp/kubectl apply -f -
           resources:
           {{- if .Values.resources }}
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml .Values.resources | nindent 12 }}
           {{- else }}
             requests:
               cpu: 500m

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -37,13 +37,7 @@ podLabels: {}
 
 # Resource requests/limits to specify for the Velero deployment.
 # https://velero.io/docs/v1.6/customize-installation/#customize-resource-requests-and-limits
-resources:
-  requests:
-    cpu: 500m
-    memory: 128Mi
-  limits:
-    cpu: 1000m
-    memory: 512Mi
+resources: {}
 
 # Configure the dnsPolicy of the Velero deployment
 # See: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
@@ -323,13 +317,7 @@ restic:
   priorityClassName: ""
   # Resource requests/limits to specify for the Restic daemonset deployment. Optional.
   # https://velero.io/docs/v1.6/customize-installation/#customize-resource-requests-and-limits
-  resources:
-    requests:
-      cpu: 500m
-      memory: 512Mi
-    limits:
-      cpu: 1000m
-      memory: 1024Mi
+  resources: {}
 
   # Tolerations to use for the Restic daemonset. Optional.
   tolerations: []


### PR DESCRIPTION
Signed-off-by: Felix Farjsjo <felix.farjsjo@gmail.com>

#### Special notes for your reviewer:
As described in #353 you are not able to properly overwrite the default Resource Requests/Limits set in `charts/velero/values.yaml` with empty or `null`/`~` values taken from a different values file (e.g. as input via `-f` flag to `helm upgrade`). 
When you do, it is interpreted as empty and the default values is chosen.   
There are some use cases in which you would want to not have any values at all for CPU/MEM Requests/Limits and this PR enables that use case.

https://github.com/vmware-tanzu/helm-charts/issues/353

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
