### PR TITLE
[velero] helm: be consistent: add namespace vars everywhere

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.8.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 2.28.0
+version: 2.28.1
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/backupstoragelocation.yaml
+++ b/charts/velero/templates/backupstoragelocation.yaml
@@ -3,6 +3,7 @@ apiVersion: velero.io/v1
 kind: BackupStorageLocation
 metadata:
   name: {{ include "velero.backupStorageLocation.name" . }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade,post-rollback
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/velero/templates/configmaps.yaml
+++ b/charts/velero/templates/configmaps.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "velero.fullname" $ }}-{{ $configMapName }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -6,6 +6,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "velero.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/velero/templates/restic-daemonset.yaml
+++ b/charts/velero/templates/restic-daemonset.yaml
@@ -6,6 +6,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: restic
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.restic.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/velero/templates/role.yaml
+++ b/charts/velero/templates/role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "velero.fullname" . }}-server
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: {{ include "velero.name" . }}

--- a/charts/velero/templates/rolebinding.yaml
+++ b/charts/velero/templates/rolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "velero.fullname" . }}-server
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: {{ include "velero.name" . }}

--- a/charts/velero/templates/schedule.yaml
+++ b/charts/velero/templates/schedule.yaml
@@ -4,6 +4,7 @@ apiVersion: velero.io/v1
 kind: Schedule
 metadata:
   name: {{ include "velero.fullname" $ }}-{{ $scheduleName }}
+  namespace: {{ $.Release.Namespace }}
   annotations:
   {{- if $schedule.annotations }}
     {{- toYaml $schedule.annotations | nindent 4 }}

--- a/charts/velero/templates/secret.yaml
+++ b/charts/velero/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "velero.secretName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/velero/templates/service.yaml
+++ b/charts/velero/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "velero.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.metrics.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/velero/templates/serviceaccount-server.yaml
+++ b/charts/velero/templates/serviceaccount-server.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "velero.serverServiceAccount" . }}
+  namespace: {{ .Release.Namespace }}
 {{- if .Values.serviceAccount.server.annotations }}
   annotations:
 {{ toYaml .Values.serviceAccount.server.annotations | nindent 4 }}

--- a/charts/velero/templates/volumesnapshotlocation.yaml
+++ b/charts/velero/templates/volumesnapshotlocation.yaml
@@ -3,6 +3,7 @@ apiVersion: velero.io/v1
 kind: VolumeSnapshotLocation
 metadata:
   name: {{ include "velero.volumeSnapshotLocation.name" . }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade,post-rollback
     "helm.sh/hook-delete-policy": before-hook-creation


### PR DESCRIPTION
Hi,

This is "controversial" as some people like not specifying the namespace
on the helm definitions and instead rely on specifying it afterwards
doing a `helm template | kubectl -n foo create -f -`.

However, as some resources definitely need a namespace
(ClusterRoleBinding for example), thus the namespace *needs* to be specified
on both commands `helm template --namespace foo | kubectl -n foo` which
creates redundancy.

In order to be consistent, we specify the `namespace` param on every
resource. This was already the case in the
[charts/velero/templates/update-crds.yaml] file, so we just make it
consistent across every resource.

Signed-off-by: Frank Villaro-Dixon <frank.villaro@infomaniak.com>

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
