### PR TITLE
[velero] Remove label `app.kubernetes.io/name: velero` from Velero CRDs

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.8.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 2.29.3
+version: 2.29.4
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/crds/backups.yaml
+++ b/charts/velero/crds/backups.yaml
@@ -4,7 +4,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: velero
     component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0

--- a/charts/velero/crds/backupstoragelocations.yaml
+++ b/charts/velero/crds/backupstoragelocations.yaml
@@ -4,7 +4,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: velero
     component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0

--- a/charts/velero/crds/deletebackuprequests.yaml
+++ b/charts/velero/crds/deletebackuprequests.yaml
@@ -4,7 +4,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: velero
     component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0

--- a/charts/velero/crds/downloadrequests.yaml
+++ b/charts/velero/crds/downloadrequests.yaml
@@ -4,7 +4,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: velero
     component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0

--- a/charts/velero/crds/podvolumebackups.yaml
+++ b/charts/velero/crds/podvolumebackups.yaml
@@ -4,7 +4,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: velero
     component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0

--- a/charts/velero/crds/podvolumerestores.yaml
+++ b/charts/velero/crds/podvolumerestores.yaml
@@ -4,7 +4,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: velero
     component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0

--- a/charts/velero/crds/resticrepositories.yaml
+++ b/charts/velero/crds/resticrepositories.yaml
@@ -4,7 +4,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: velero
     component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0

--- a/charts/velero/crds/restores.yaml
+++ b/charts/velero/crds/restores.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: velero
     component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0

--- a/charts/velero/crds/schedules.yaml
+++ b/charts/velero/crds/schedules.yaml
@@ -4,7 +4,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: velero
     component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0

--- a/charts/velero/crds/serverstatusrequests.yaml
+++ b/charts/velero/crds/serverstatusrequests.yaml
@@ -4,7 +4,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: velero
     component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0

--- a/charts/velero/crds/volumesnapshotlocations.yaml
+++ b/charts/velero/crds/volumesnapshotlocations.yaml
@@ -4,7 +4,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: velero
     component: velero
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0

--- a/charts/velero/templates/cleanup-crds.yaml
+++ b/charts/velero/templates/cleanup-crds.yaml
@@ -56,7 +56,7 @@ spec:
               kubectl delete backupstoragelocation --all;
               kubectl delete volumesnapshotlocation --all;
               kubectl delete podvolumerestore --all;
-              kubectl delete crd -l app.kubernetes.io/name=velero;
+              kubectl delete crd -l component=velero;
           {{- with .Values.kubectl.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
#### Special notes for your reviewer:

Make the Velero CLI install CRD labels the same as as helm chart install CRD labels.

fix #350

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] ~Variables are documented in the values.yaml or README.md~
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
