### PR TITLE
[velero] Only install ServiceMonitor when monitoring API is available

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.8.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 2.29.4
+version: 2.29.5
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.8.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 2.29.5
+version: 2.29.6
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/servicemonitor.yaml
+++ b/charts/velero/templates/servicemonitor.yaml
@@ -1,4 +1,8 @@
-{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+{{- if and
+  .Values.metrics.enabled
+  .Values.metrics.serviceMonitor.enabled
+  (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")
+}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
Signed-off-by: Arie Peterson <arie@greenhost.nl>

#### Special notes for your reviewer:
With this change, the ServiceMonitor is only installed if the corresponding monitoring API is available on the cluster (and the proper helm values are enabled, as before). This way, we can safely enable the servicemonitor in our helm values for velero that are used on many clusters, some of which have the monitoring API/prometheus and some of which do not. The unattractive alternative would be to have some complex mechanism to conditionally set the helm value depending on the cluster configuration.

This is inspired by the [same construct in another helm chart](https://github.com/ory/k8s/blob/master/helm/charts/hydra/templates/service-admin.yaml#L28).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
