### PR TITLE
[velero] Add DNSConfig.

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.9.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 2.30.2
+version: 2.31.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -216,6 +216,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/velero/templates/restic-daemonset.yaml
+++ b/charts/velero/templates/restic-daemonset.yaml
@@ -178,4 +178,8 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+    {{- with .Values.restic.dnsConfig }}
+    dnsConfig:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
 {{- end }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -92,6 +92,9 @@ affinity: {}
 # Node selector to use for the Velero deployment. Optional.
 nodeSelector: {}
 
+# DNS configuration to use for the Velero deployment. Optional.
+dnsConfig: {}
+
 # Extra volumes for the Velero deployment. Optional.
 extraVolumes: []
 
@@ -402,6 +405,9 @@ restic:
 
   # Node selector to use for the Restic daemonset. Optional.
   nodeSelector: {}
+
+  # DNS configuration to use for the Restic daemonset. Optional.
+  dnsConfig: {}
 
 # Backup schedules to create.
 # Eg:


### PR DESCRIPTION
Adding ability to set a custom dnsConfig for the pods. Pod's DNS Config field enable users more control on the DNS settings for the pods.
This can help on optimizing DNS search path.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
