### PR TITLE
[velero] Add extra env variables for restic only

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.9.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 2.30.1
+version: 2.30.2
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/restic-daemonset.yaml
+++ b/charts/velero/templates/restic-daemonset.yaml
@@ -155,6 +155,12 @@ spec:
                   key: {{ default "none" $key }}
           {{- end }}
           {{- end }}
+          {{- with .Values.restic.extraEnvVars }}
+          {{- range $key, $value := . }}
+            - name: {{ default "none" $key }}
+              value: {{ default "none" $value | quote }}
+          {{- end }}
+          {{- end }}
           securityContext:
             privileged: {{ .Values.restic.privileged }}
             {{- with $containerSecurityContext }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -382,6 +382,9 @@ restic:
   # Extra volumeMounts for the Restic daemonset. Optional.
   extraVolumeMounts: []
 
+  # Key/value pairs to be used as environment variables for the Restic daemonset. Optional.
+  extraEnvVars: {}
+
   # Configure the dnsPolicy of the Restic daemonset
   # See: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
   dnsPolicy: ClusterFirst


### PR DESCRIPTION
#### Goal of the PR : 
Adding ability to add environments variables **only** to the Restic daemonset. For example : `GOGC=20` 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
