### PR TITLE
[velero] Added affinity to restic

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.9.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 2.31.3
+version: 2.31.4
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/restic-daemonset.yaml
+++ b/charts/velero/templates/restic-daemonset.yaml
@@ -178,6 +178,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.restic.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}      
     {{- with .Values.restic.dnsConfig }}
     dnsConfig:
       {{- toYaml . | nindent 8 }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -410,6 +410,9 @@ restic:
   # Node selector to use for the Restic daemonset. Optional.
   nodeSelector: {}
 
+  # Affinity to use with Restic daemonset. Optional.
+  affinity: {}
+
   # DNS configuration to use for the Restic daemonset. Optional.
   dnsConfig: {}
 


### PR DESCRIPTION
#### Special notes for your reviewer:
Added affinity to restic daemonset to bring it inline with velero deployment

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Peter Bone <peter.bone@glassbox.com>
