### PR TITLE
[velero] Set Deployment Strategy to Recreate

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.9.2
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 2.31.8
+version: 2.32.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -22,6 +22,8 @@ metadata:
     {{- end }}
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
#### Special notes for your reviewer:
If we're limiting the replica count to a single replica, we should also set the deployment strategy type to "Recreate" to avoid having two instances running, however briefly, at the same time.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
