### PR TITLE
[velero] Add Termination Grace Period Helm Value

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.9.2
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 2.31.8
+version: 2.31.9
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -58,6 +58,7 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ include "velero.priorityClassName" . }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       containers:
         - name: velero
       {{- if .Values.image.digest }}

--- a/charts/velero/templates/restic-daemonset.yaml
+++ b/charts/velero/templates/restic-daemonset.yaml
@@ -53,6 +53,7 @@ spec:
       {{- if .Values.restic.priorityClassName }}
       priorityClassName: {{ include "velero.restic.priorityClassName" . }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       volumes:
         {{- if .Values.credentials.useSecret }}
         - name: cloud-credentials

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -86,6 +86,9 @@ lifecycle: {}
 # Pod priority class name to use for the Velero deployment. Optional.
 priorityClassName: ""
 
+# The number of seconds to allow for graceful termination of the pod. Optional.
+terminationGracePeriodSeconds: 3600
+
 # Tolerations to use for the Velero deployment. Optional.
 tolerations: []
 


### PR DESCRIPTION
Adds in the ability to specify the termination grace period to the Helm chart. Primary use case is to allow Velero to finish a backup before terminating in case it takes more than the default, previously immutable, 30 seconds to perform a backup.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
