### PR TITLE
[velero] Adding garbageCollectionFrequency to velero server

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.9.2
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 2.32.0
+version: 2.32.1
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -121,6 +121,12 @@ spec:
             {{- with .storeValidationFrequency }}
             - --store-validation-frequency={{ . }}
             {{- end }}
+            {{- with .garbageCollectionFrequency }}
+            - --garbage-collection-frequency={{ . }}
+            {{- end }}
+            {{- with .extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- with .Values.resources }}
           resources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -124,9 +124,6 @@ spec:
             {{- with .garbageCollectionFrequency }}
             - --garbage-collection-frequency={{ . }}
             {{- end }}
-            {{- with .extraArgs }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
           {{- end }}
           {{- with .Values.resources }}
           resources:

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -304,8 +304,6 @@ configuration:
   storeValidationFrequency:
   # `velero server` default: 1h
   garbageCollectionFrequency:
-  # `velero server` default: []
-  extraArgs: []
   #
 
   # additional key/value pairs to be used as environment variables such as "AWS_CLUSTER_NAME: 'yourcluster.domain.tld'"

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -302,6 +302,10 @@ configuration:
   disableControllers:
   # `velero server` default: 1m
   storeValidationFrequency:
+  # `velero server` default: 1h
+  garbageCollectionFrequency:
+  # `velero server` default: []
+  extraArgs: []
   #
 
   # additional key/value pairs to be used as environment variables such as "AWS_CLUSTER_NAME: 'yourcluster.domain.tld'"


### PR DESCRIPTION
Signed-off-by: Arthur Burle <arthurburle@gmail.com>

#### Special notes for your reviewer:
The purpose of this PR is to allow the Chart user to set the flag `garbageCollectionFrequency` to the `velero server` command.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)