### PR TITLE
[velero] Add support to change namespace argument in velero deployment

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.9.3
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 2.32.2
+version: 2.32.3
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -124,6 +124,9 @@ spec:
             {{- with .garbageCollectionFrequency }}
             - --garbage-collection-frequency={{ . }}
             {{- end }}
+            {{- with .namespace }}
+            - --namespace={{ . }}
+            {{- end }}
           {{- end }}
           {{- with .Values.resources }}
           resources:

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -304,6 +304,8 @@ configuration:
   storeValidationFrequency:
   # `velero server` default: 1h
   garbageCollectionFrequency:
+  # `velero server` default: velero
+  namespace:
   #
 
   # additional key/value pairs to be used as environment variables such as "AWS_CLUSTER_NAME: 'yourcluster.domain.tld'"


### PR DESCRIPTION
Allow users to change namespace in which Velero operates using values.

Signed-off-by: Ondrej Vasko <ondrej.vaskoo@gmail.com>

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
