### PR TITLE
[velero] Add missing velero server flags

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.9.4
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 2.32.5
+version: 2.32.6
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -78,9 +78,55 @@ spec:
             - /velero
           args:
             - server
+            ### Flags
           {{- with .Values.configuration }}
             {{- with .backupSyncPeriod }}
             - --backup-sync-period={{ . }}
+            {{- end }}
+            {{- with .clientBurst }}
+            - --client-burst={{ . }}
+            {{- end }}
+            {{- with .clientPageSize }}
+            - --client-page-size={{ . }}
+            {{- end }}
+            {{- with .clientQPS }}
+            - --client-qps={{ . }}
+            {{- end }}
+            {{- with .defaultBackupStorageLocation }}
+            - --default-backup-storage-location={{ . }}
+            {{- end }}
+            {{- with .defaultBackupTTL }}
+            - --default-backup-ttl={{ . }}
+            {{- end }}
+            {{- with .defaultResticPruneFrequency }}
+            - --default-restic-prune-frequency={{ . }}
+            {{- end }}
+            {{- with .defaultVolumeSnapshotLocations }}
+            - --default-volume-snapshot-locations={{ . }}
+            {{- end }}
+            {{- if .defaultVolumesToRestic }}
+            - --default-volumes-to-restic
+            {{- end }}
+            {{- with .disableControllers }}
+            - --disable-controllers={{ . }}
+            {{- end }}
+            {{- with .garbageCollectionFrequency }}
+            - --garbage-collection-frequency={{ . }}
+            {{- end }}
+            {{- with .logFormat }}
+            - --log-format={{ . }}
+            {{- end }}
+            {{- with .logLevel }}
+            - --log-level={{ . }}
+            {{- end }}
+            {{- with .metricsAddress }}
+            - --metrics-address={{ . }}
+            {{- end }}
+            {{- with .pluginDir }}
+            - --plugin-dir={{ . }}
+            {{- end }}
+            {{- with .profilerAddress }}
+            - --profiler-address={{ . }}
             {{- end }}
             {{- with .resticTimeout }}
             - --restic-timeout={{ . }}
@@ -91,38 +137,15 @@ spec:
             {{- with .restoreResourcePriorities }}
             - --restore-resource-priorities={{ . }}
             {{- end }}
-            {{- with .features }}
-            - --features={{ . }}
-            {{- end }}
-            {{- with .logLevel }}
-            - --log-level={{ . }}
-            {{- end }}
-            {{- with .logFormat }}
-            - --log-format={{ . }}
-            {{- end }}
-            {{- if .defaultVolumesToRestic }}
-            - --default-volumes-to-restic
-            {{- end }}
-            {{- with .defaultResticPruneFrequency }}
-            - --default-restic-prune-frequency={{ . }}
-            {{- end }}
-            {{- with .clientQPS }}
-            - --client-qps={{ . }}
-            {{- end }}
-            {{- with .clientBurst }}
-            - --client-burst={{ . }}
-            {{- end }}
-            {{- with .clientPageSize }}
-            - --client-page-size={{ . }}
-            {{- end }}
-            {{- with .disableControllers }}
-            - --disable-controllers={{ . }}
-            {{- end }}
             {{- with .storeValidationFrequency }}
             - --store-validation-frequency={{ . }}
             {{- end }}
-            {{- with .garbageCollectionFrequency }}
-            - --garbage-collection-frequency={{ . }}
+            {{- with .terminatingResourceTimeout }}
+            - --terminating-resource-timeout={{ . }}
+            {{- end }}
+            ### Global Flags
+            {{- with .features }}
+            - --features={{ . }}
             {{- end }}
             {{- with .namespace }}
             - --namespace={{ . }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -286,46 +286,54 @@ configuration:
   # --------------------
   # `velero server` default: 1m
   backupSyncPeriod:
-  # `velero server` default: 1h
-  resticTimeout:
-  # `velero server` default: namespaces,persistentvolumes,persistentvolumeclaims,secrets,configmaps,serviceaccounts,limitranges,pods
-  restoreResourcePriorities:
-  # `velero server` default: false
-  restoreOnlyMode:
-  # `velero server` default: 20.0
-  clientQPS:
   # `velero server` default: 30
   clientBurst:
-  # `velero server` default: empty
+  # `velero server` default: 500
   clientPageSize:
+  # `velero server` default: 20.0
+  clientQPS:
+  # Name of the default backup storage location. Default: default
+  defaultBackupStorageLocation:
+  # How long to wait by default before backups can be garbage collected. Default: 72h
+  defaultBackupTTL:
+  # How often 'restic prune' is run for restic repositories by default. Default: 168h. Optional.
+  defaultResticPruneFrequency:
+  # Name of the default volume snapshot location.
+  defaultVolumeSnapshotLocations:
+  # Set true for backup all pod volumes without having to apply annotation on the pod when used restic Default: false. Other option: false.
+  defaultVolumesToRestic:
   # `velero server` default: empty
   disableControllers:
-  # `velero server` default: 1m
-  storeValidationFrequency:
   # `velero server` default: 1h
   garbageCollectionFrequency:
-  # `velero server` default: velero
-  namespace:
-  #
-
-  # additional key/value pairs to be used as environment variables such as "AWS_CLUSTER_NAME: 'yourcluster.domain.tld'"
-  extraEnvVars: {}
-
+  # Set log-format for Velero pod. Default: text. Other option: json.
+  logFormat:
+  # Set log-level for Velero pod. Default: info. Other options: debug, warning, error, fatal, panic.
+  logLevel:
+  # The address to expose prometheus metrics. Default: :8085
+  metricsAddress:
+  # Directory containing Velero plugins. Default: /plugins
+  pluginDir:
+  # The address to expose the pprof profiler. Default: localhost:6060
+  profilerAddress:
+  # `velero server` default: 4h
+  resticTimeout:
+  # `velero server` default: false
+  restoreOnlyMode:
+  # `velero server` default: customresourcedefinitions,namespaces,storageclasses,volumesnapshotclass.snapshot.storage.k8s.io,volumesnapshotcontents.snapshot.storage.k8s.io,volumesnapshots.snapshot.storage.k8s.io,persistentvolumes,persistentvolumeclaims,secrets,configmaps,serviceaccounts,limitranges,pods,replicasets.apps,clusterclasses.cluster.x-k8s.io,clusters.cluster.x-k8s.io,clusterresourcesets.addons.cluster.x-k8s.io
+  restoreResourcePriorities:
+  # `velero server` default: 1m
+  storeValidationFrequency:
+  # How long to wait on persistent volumes and namespaces to terminate during a restore before timing out. Default: 10m
+  terminatingResourceTimeout:
   # Comma separated list of velero feature flags. default: empty
   # features: EnableCSI
   features:
+  # `velero server` default: velero
+  namespace:
 
-  # Set log-level for Velero pod. Default: info. Other options: debug, warning, error, fatal, panic.
-  logLevel:
-
-  # Set log-format for Velero pod. Default: text. Other option: json.
-  logFormat:
-
-  # Set true for backup all pod volumes without having to apply annotation on the pod when used restic Default: false. Other option: false.
-  defaultVolumesToRestic:
-
-  # How often 'restic prune' is run for restic repositories by default. Default: 168h. Optional.
-  defaultResticPruneFrequency:
+  # additional key/value pairs to be used as environment variables such as "AWS_CLUSTER_NAME: 'yourcluster.domain.tld'"
+  extraEnvVars: {}
 
 ##
 ## End of backup/snapshot location settings.


### PR DESCRIPTION
#### Special notes for your reviewer:

Add missing velero server flags.
- --default-backup-storage-location
- --default-backup-ttl
- --default-volume-snapshot-locations
- --metrics-address
- --plugin-dir
- --profiler-address
- --terminating-resource-timeout

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
