### PR TITLE
[velero] use value instead of key for extraEnvVars

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.9.4
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 2.32.4
+version: 2.32.5
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -194,7 +194,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "velero.secretName" $ }}
-                  key: {{ default "none" $key }}
+                  key: {{ default "none" $value }}
           {{- end }}
           {{- end }}
           {{- if .Values.lifecycle }}


### PR DESCRIPTION
Signed-off-by: k4mrul <kamrulahsan06@gmail.com>

#### Special notes for your reviewer: Use value instead of key for `credentials.extraEnvVars`
```
credentials:
  extraEnvVars: 
    DIGITALOCEAN_TOKEN: do_token  <-- Currently this value is ignored.
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
