### PR TITLE
[velero] fix: secret credentials key

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.10.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 3.0.0
+version: 3.0.1
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -218,7 +218,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "velero.secretName" $ }}
-                  key: {{ default "none" $value }}
+                  key: {{ default "none" $key }}
           {{- end }}
           {{- end }}
           {{- if .Values.lifecycle }}


### PR DESCRIPTION
Use `key` as `key` for `secretRef` instead of `value`.

Error on current version when using `credentials.extraEnvVars`:
```
Helm release "velero/velero" failed to initialize completely. Use Helm CLI to investigate.: failed to become available within allocated timeout. Error: Helm Release velero/velero: cannot patch "velero" with kind Deployment: Deployment.apps "velero" is invalid: spec.template.spec.containers[0].env[6].valueFrom.secretKeyRef.key: Invalid value: "<e.g. AWS secret access key>": a valid config key must consist of alphanumeric characters, '-', '_' or '.' (e.g. 'key.name',  or 'KEY_NAME',  or 'key-name', regex used for validation is '[-._a-zA-Z0-9]+')
```

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
