### PR TITLE
velero: Switch order of init container & main in update-crds job

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.10.2
+appVersion: 1.10.3
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero

--- a/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
@@ -64,7 +64,7 @@ spec:
         - name: kubectl
           {{- if .Values.kubectl.image.digest }}
           image: "{{ .Values.kubectl.image.repository }}@{{ .Values.kubectl.image.digest }}"
-          {{- else .Values.kubectl.image.tag }}
+          {{- else if .Values.kubectl.image.tag }}
           image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
           {{- else }}
           image: "{{ .Values.kubectl.image.repository }}:{{ template "chart.KubernetesVersion" . }}"

--- a/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
@@ -37,32 +37,6 @@ spec:
     {{- end }}
       serviceAccountName: {{ include "velero.serverServiceAccount" . }}-upgrade-crds
       initContainers:
-        - name: kubectl
-          {{- if .Values.kubectl.image.digest }}
-          image: "{{ .Values.kubectl.image.repository }}@{{ .Values.kubectl.image.digest }}"
-          {{- else if .Values.kubectl.image.tag }}
-          image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
-          {{- else }}
-          image: "{{ .Values.kubectl.image.repository }}:{{ template "chart.KubernetesVersion" . }}"
-          {{- end }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
-            - /bin/sh
-          args:
-            - -c
-            - cp `which sh` /tmp && cp `which kubectl` /tmp
-          {{- with .Values.kubectl.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.kubectl.containerSecurityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          volumeMounts:
-            - mountPath: /tmp
-              name: crds
-      containers:
         - name: velero
           {{- if .Values.image.digest }}
           image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
@@ -71,15 +45,41 @@ spec:
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
-            - /tmp/sh
+            - /bin/sh
           args:
             - -c
-            - /velero install --crds-only --dry-run -o yaml | /tmp/kubectl apply -f -
+            - /velero install --crds-only --dry-run -o yaml > /tmp/velero-crds.yaml
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - mountPath: /tmp
+              name: crds
+      containers:
+        - name: kubectl
+          {{- if .Values.kubectl.image.digest }}
+          image: "{{ .Values.kubectl.image.repository }}@{{ .Values.kubectl.image.digest }}"
+          {{- else .Values.kubectl.image.tag }}
+          image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
+          {{- else }}
+          image: "{{ .Values.kubectl.image.repository }}:{{ template "chart.KubernetesVersion" . }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.kubectl.image.pullPolicy }}
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - kubectl apply -f /tmp/velero-crds.yaml
+          {{- with .Values.kubectl.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.kubectl.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
#### Special notes for your reviewer:

we're copying `sh` and `kubectl` over to `velero` image but doing this required that kubectl image and velero image are same OS (shared libs, etc..)

I'm re-ordering `velero` to be init container and will generate CRD yaml to `/tmp`.

main container will be `kubectl` and only apply the generated yaml file in there. This way, we can say use kubectl alpine version built with musl and velero image can be Debian based for example.

use case:
- bitnami/kubectl has lots of CVE and we want to switch to sth else.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
