### PR TITLE
[velero] Add multiple replicas support

### DIFF
--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -21,7 +21,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicas }}
   strategy:
     type: Recreate
   selector:

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -2,6 +2,9 @@
 ## Configuration settings that directly affect the Velero deployment YAML.
 ##
 
+# Number of Velero server to deploy
+replicas: 1
+
 # Details of the container image to use in the Velero deployment & daemonset (if
 # enabling node-agent). Required.
 image:


### PR DESCRIPTION
#### Special notes for your reviewer:

This change support multi deployment of the velero server with while keeping the default to 1.

⚠️  ⚠️ This is Assuming that the velero server knows to consume each CRD objects once and  it will not going to duplicate / repeat same action per instance/replica.

If this assumption is not true, please feel free to close this pr . (A comment will be nice)
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)

I've tested this chart from this forked.
If a chart bump is needed i will add it.