### PR TITLE
[velero] Add dependabot file to auto create PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "docker" # See documentation for possible values
+    directory: "/charts/velero/" # Location of package manifests
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
#### Special notes for your reviewer:

#364

This is the [demo PR](https://github.com/jenting/vmware-tanzu-helm-charts/pull/6).

TODOs:
- Have the CI task to verify the CRD folder in sync
- Bump the chart version (but we could do it manually after the auto PR created)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
