### PR TITLE
[velero] create prometheusRule only if capabilities are present

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.11.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 4.1.4
+version: 4.1.5
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/prometheusrule.yaml
+++ b/charts/velero/templates/prometheusrule.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metrics.enabled .Values.metrics.prometheusRule.enabled }}
+{{- if and (and .Values.metrics.enabled .Values.metrics.prometheusRule.enabled) (or (not .Values.metrics.prometheusRule.autodetect) (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) (.Values.metrics.prometheusRule.spec) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -198,6 +198,7 @@ metrics:
     # tlsConfig: {}
 
   prometheusRule:
+    autodetect: true
     enabled: false
     # Additional labels to add to deployed PrometheusRule
     additionalLabels: {}


### PR DESCRIPTION
#### Special notes for your reviewer:

Similar to existing `podMonitor` and `serviceMonitor` templates, only create the `prometheusRule` if the capabilities are present in the cluster (and rules are defined).

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
