### PR TITLE
[velero] Remove helm hooks for the custom resources

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -27,34 +27,35 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.8.1
+          version: v3.11.2
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: '3.9'
+          check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.2.1
+        uses: helm/chart-testing-action@v2.4.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
           changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
         run: ct lint --target-branch ${{ github.event.repository.default_branch }}
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@v1.5.0
+        if: steps.list-changed.outputs.changed == 'true'
         with:
           version: "v0.14.0"
           node_image: "kindest/node:v${{ matrix.k8s }}"
-        # Only build a kind cluster if there are chart changes to test.
-        if: steps.list-changed.outputs.changed == 'true'
 
-      - name: Run chart-testing (install)
-        run: ct install
+      - name: Run chart-testing (install+upgrade)
         if: steps.list-changed.outputs.changed == 'true'
+        run: ct install --upgrade --target-branch ${{ github.event.repository.default_branch }}

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.11.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 4.4.1
+version: 5.0.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/backupstoragelocation.yaml
+++ b/charts/velero/templates/backupstoragelocation.yaml
@@ -8,11 +8,6 @@ kind: BackupStorageLocation
 metadata:
   name: {{ .name | default "default" }}
   namespace: {{ $.Release.Namespace }}
-  annotations:
-    {{- if $.Values.helmHookAnnotations }}
-    "helm.sh/hook": post-install,post-upgrade,post-rollback
-    "helm.sh/hook-delete-policy": before-hook-creation
-    {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}

--- a/charts/velero/templates/schedule.yaml
+++ b/charts/velero/templates/schedule.yaml
@@ -9,10 +9,6 @@ metadata:
   {{- if $schedule.annotations }}
     {{- toYaml $schedule.annotations | nindent 4 }}
   {{- end }}
-  {{- if $.Values.helmHookAnnotations }}
-    "helm.sh/hook": post-install,post-upgrade,post-rollback
-    "helm.sh/hook-delete-policy": before-hook-creation
-  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}

--- a/charts/velero/templates/volumesnapshotlocation.yaml
+++ b/charts/velero/templates/volumesnapshotlocation.yaml
@@ -8,11 +8,6 @@ kind: VolumeSnapshotLocation
 metadata:
   name: {{ .name | default "default" }}
   namespace: {{ $.Release.Namespace }}
-  annotations:
-    {{- if $.Values.helmHookAnnotations }}
-    "helm.sh/hook": post-install,post-upgrade,post-rollback
-    "helm.sh/hook-delete-policy": before-hook-creation
-    {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -27,10 +27,6 @@ annotations: {}
 # Labels to add to the Velero deployment's. Optional.
 labels: {}
 
-# helmHookAnnotations is required to deploy CustomResources after deploying CRDs. If you manage your CRDs outside of this helm chart
-# or using ArgoCD, you are able to disable the helm hooks annotations.
-helmHookAnnotations: true
-
 # Annotations to add to the Velero deployment's pod template. Optional.
 #
 # If using kube2iam or kiam, use the following annotation with your AWS_ACCOUNT_ID


### PR DESCRIPTION
#### Special notes for your reviewer:

The PR #414 have moved the upgrade CRD job from post hook to pre hook to ensure that the custom resources create/upgrade after the CRD installed/upgraded.

Therefore, the helm hooks for the custom resources are no longer required includes
- backupstoragelocations.velero.io
- volumesnapshotlocations.velero.io
- schedules.velero.io

Fixes #298 #392 #435 #462

> [!IMPORTANT]
> It's a breaking change during helm upgrade because the backupstoragelocations.velero.io, volumesnapshotlocations.velero.io, schedules.velero.io which were created by helm hooks does not includes the two annotations
> - meta.helm.sh/release-name
> - meta.helm.sh/release-namespace
> 
> Removing the helm hooks, the helm upgrade requires the above two annotations existed.
> The workaround is manually remove the backupstoragelocations.velero.io, volumesnapshotlocations.velero.io, schedules.velero.io and recreated by helm upgrade.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
