### PR TITLE
[velero] Setting podAnnotations metrics only if not using servicemonitor or podmonitor

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.11.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 5.0.0
+version: 5.0.1
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -45,8 +45,10 @@ spec:
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.metrics.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
+      {{- if and (.Values.metrics.enabled) (not .Values.metrics.serviceMonitor.enabled) }}
+        {{- with .Values.metrics.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
     {{- end }}
     spec:

--- a/charts/velero/templates/node-agent-daemonset.yaml
+++ b/charts/velero/templates/node-agent-daemonset.yaml
@@ -33,10 +33,17 @@ spec:
       {{- if .Values.podLabels }}
         {{- toYaml .Values.podLabels | nindent 8 }}
       {{- end }}
-      {{- with .Values.podAnnotations }}
+    {{- if or .Values.podAnnotations .Values.metrics.enabled }}
       annotations:
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if and (.Values.metrics.enabled) (not .Values.metrics.nodeAgentPodMonitor.enabled) }}
+        {{- with .Values.metrics.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
     spec:
     {{- if .Values.image.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
There are two ways to enable Prometheus scraping : 

- If using Prometheus Operator, you have to create ServiceMonitors or PodMonitors crds.
- If using Prometheus without Operator, you have to define scraping configuration in pods annotation.

Adding pod scraping annotations and ServiceMonitor (or podMonitor) for the same pod will result to get metrics being collected twice by Prometheus.

This PR intend to add metrics.PodAnnotations only if 'metrics' is enable but metrics.ServiceMonitor and metrics.nodeAgentPodMonitor are **not** enabled.

Fixes #336

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
