### PR TITLE
[velero] Add secret annotations

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.12.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 5.1.1
+version: 5.1.2
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.12.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 5.1.0
+version: 5.1.1
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.12.0
+appVersion: 1.12.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero

--- a/charts/velero/templates/secret.yaml
+++ b/charts/velero/templates/secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "velero.secretName" . }}
-  namespace: {{ .Release.Namespace }}}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.secretAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/velero/templates/secret.yaml
+++ b/charts/velero/templates/secret.yaml
@@ -3,7 +3,11 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "velero.secretName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}}
+  {{- with .Values.secretAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -33,7 +33,7 @@ namespace:
 # enabling node-agent). Required.
 image:
   repository: velero/velero
-  tag: v1.12.0
+  tag: v1.12.1
   # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
   # If used, it will take precedence over the image.tag.
   # digest:

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -51,6 +51,9 @@ fullnameOverride: ""
 annotations: {}
 # secret.reloader.stakater.com/reload: "<VELERO_SECRET_NAME>"
 
+# Annotations to add to secret
+secretAnnotations: {}
+
 # Labels to add to the Velero deployment's. Optional.
 labels: {}
 


### PR DESCRIPTION
#### Special notes for your reviewer:
We use vault webhook to inject the secrets retrieved from [HashiCorp Vault](https://www.hashicorp.com/products/vault) directly into the Pods/Secrets/etc via annotations(https://bank-vaults.dev/docs/mutating-webhook/annotations/).

For e.g:
```
secretAnnotations:
  vault.security.banzaicloud.io/vault-serviceaccount: velero
  vault.security.banzaicloud.io/vault-role: velero
  
velero, Secret (v1) has been added:
+ # Source: velero/templates/secret.yaml
+ apiVersion: v1
+ kind: Secret
+ metadata:
+   annotations:
+     vault.security.banzaicloud.io/vault-role: velero
+     vault.security.banzaicloud.io/vault-serviceaccount: velero
+   labels:
+     app.kubernetes.io/instance: velero
+     app.kubernetes.io/managed-by: Helm
+     app.kubernetes.io/name: velero
+     helm.sh/chart: velero-5.1.0
+   name: velero
+   namespace: velero}
+ data:
+   default: '++++++++ # (226 bytes)'
+ type: Opaque
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
