### PR TITLE
[velero] Have separate resource usages for velero server pod and upgradeCRDs job pod

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -35,7 +35,7 @@ jobs:
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.12.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 5.1.2
+version: 5.1.3
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -155,7 +155,7 @@ spec:
             - --namespace={{ . }}
             {{- end }}
           {{- end }}
-          {{- with .Values.resources }}
+          {{- with .Values.resources.server }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -155,7 +155,7 @@ spec:
             - --namespace={{ . }}
             {{- end }}
           {{- end }}
-          {{- with .Values.resources.server }}
+          {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
@@ -75,7 +75,7 @@ spec:
           args:
             - -c
             - /velero install --crds-only --dry-run -o yaml | /tmp/kubectl apply -f -
-          {{- with .Values.resources }}
+          {{- with .Values.resources.upgradeJob }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
@@ -75,7 +75,7 @@ spec:
           args:
             - -c
             - /velero install --crds-only --dry-run -o yaml | /tmp/kubectl apply -f -
-          {{- with .Values.resources.upgradeJob }}
+          {{- with .Values.upgradeJobResources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -71,9 +71,10 @@ podLabels: {}
 # Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)
 # revisionHistoryLimit: 1
 
-# Resource requests/limits to specify for the Velero deployment.
+# Resource requests/limits to specify for the Velero deployment and the upgrade CRDs job.
 # https://velero.io/docs/v1.6/customize-installation/#customize-resource-requests-and-limits
 resources:
+# Resource requests for the Velero deployment
   server:
     requests:
       cpu: 500m
@@ -81,6 +82,7 @@ resources:
     limits:
       cpu: 1000m
       memory: 512Mi
+# Resource requests for the upgrade CRDs job
   upgradeJob:
     requests:
       cpu: 50m

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -71,25 +71,24 @@ podLabels: {}
 # Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)
 # revisionHistoryLimit: 1
 
-# Resource requests/limits to specify for the Velero deployment and the upgrade CRDs job.
+# Resource requests/limits to specify for the Velero deployment.
 # https://velero.io/docs/v1.6/customize-installation/#customize-resource-requests-and-limits
 resources:
-# Resource requests for the Velero deployment
-  server:
-    requests:
-      cpu: 500m
-      memory: 128Mi
-    limits:
-      cpu: 1000m
-      memory: 512Mi
-# Resource requests for the upgrade CRDs job
-  upgradeJob:
-    requests:
-      cpu: 50m
-      memory: 64Mi
-    limits:
-      cpu: 100m
-      memory: 128Mi
+  requests:
+    cpu: 500m
+    memory: 128Mi
+  limits:
+    cpu: 1000m
+    memory: 512Mi
+
+# Resource requests/limits to specify for the upgradeCRDs job pod.
+upgradeJobResources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi
 
 # Configure the dnsPolicy of the Velero deployment
 # See: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -74,12 +74,20 @@ podLabels: {}
 # Resource requests/limits to specify for the Velero deployment.
 # https://velero.io/docs/v1.6/customize-installation/#customize-resource-requests-and-limits
 resources:
-  requests:
-    cpu: 500m
-    memory: 128Mi
-  limits:
-    cpu: 1000m
-    memory: 512Mi
+  server:
+    requests:
+      cpu: 500m
+      memory: 128Mi
+    limits:
+      cpu: 1000m
+      memory: 512Mi
+  upgradeJob:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
 
 # Configure the dnsPolicy of the Velero deployment
 # See: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy


### PR DESCRIPTION
#### Special notes for your reviewer:
I have added the details in this issue: https://github.com/vmware-tanzu/helm-charts/issues/513
Please take a look.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
