### PR TITLE
[velero] add labels to upgrade-crds job, not only in pod template

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.12.3
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 5.2.1
+version: 5.2.2
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
@@ -15,6 +15,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "velero.chart" . }}
+  {{- with .Values.kubectl.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   backoffLimit: 3
   template:


### PR DESCRIPTION
#### Special notes for your reviewer:
This makes it possible to add labels to the upgrade-crds job. I used the kubectl.labels value for this, but could change it to a new value to differentiate between jobLabels and podLabels.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
