### PR TITLE
[velero] Added default operation timeout override

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.13.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 5.3.0
+version: 5.4.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -108,6 +108,9 @@ spec:
             {{- with .defaultBackupTTL }}
             - --default-backup-ttl={{ . }}
             {{- end }}
+            {{- with .defaultItemOperationTimeout }}
+            - --default-item-operation-timeout={{ . }}
+            {{- end }}
             {{- with .defaultVolumeSnapshotLocations }}
             - --default-volume-snapshot-locations={{ . }}
             {{- end }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -405,6 +405,8 @@ configuration:
   clientQPS:
   # Name of the default backup storage location. Default: default
   defaultBackupStorageLocation:
+  # The default duration any single item operation can take before timing out, especially important for large volume schedules. Default 4h
+  defaultItemOperationTimeout:
   # How long to wait by default before backups can be garbage collected. Default: 72h
   defaultBackupTTL:
   # Name of the default volume snapshot location.


### PR DESCRIPTION
#### Special notes for your reviewer:

This adds the ability to set the default operation timeout, an incredibly small and backwards compatible change that is important for large volume backups via schedules which have no other means to override this option.

resolves https://github.com/vmware-tanzu/helm-charts/issues/545

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
