### PR TITLE
[velero] Allow passing custom arguments to velero server CLI

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.13.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 6.1.0
+version: 6.2.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -123,6 +123,9 @@ spec:
             {{- with .disableControllers }}
             - --disable-controllers={{ . }}
             {{- end }}
+            {{- with .disableInformerCache }}
+            - --disable-informer-cache={{ . }}
+            {{- end }}
             {{- with .garbageCollectionFrequency }}
             - --garbage-collection-frequency={{ . }}
             {{- end }}
@@ -162,6 +165,10 @@ spec:
             {{- end }}
             {{- with .namespace }}
             - --namespace={{ . }}
+            {{- end }}
+            {{- with .extraArgs }}
+            ### User-supplied overwrite flags
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
           {{- with .Values.resources }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -413,6 +413,8 @@ configuration:
   defaultVolumeSnapshotLocations:
   # `velero server` default: empty
   disableControllers:
+  # `velero server` default: false
+  disableInformerCache: false
   # `velero server` default: 1h
   garbageCollectionFrequency:
   # Set log-format for Velero pod. Default: text. Other option: json.
@@ -440,6 +442,9 @@ configuration:
   features:
   # `velero server` default: velero
   namespace:
+  # additional command-line arguments that will be passed to the `velero server`
+  # e.g.: extraArgs: ["--foo=bar"]
+  extraArgs: []
 
   # additional key/value pairs to be used as environment variables such as "AWS_CLUSTER_NAME: 'yourcluster.domain.tld'"
   extraEnvVars: {}


### PR DESCRIPTION
Hi all,

thanks for maintaining this Helm chart. It's a great help in deploying velero.

I came across a use case where I need to add a new flag for the velero server CLI (`--disable-informer-cache` in [1.13](https://github.com/vmware-tanzu/velero/releases/tag/v1.13.0)).
Over time new arguments get added to the velero CLI and I think in general it is helpful to have a generic way of setting these arguments because (for a cluster administrator) it decouples Helm charts upgrades from application (velero) upgrades.

Many other Helm charts implement this pattern as well, e.g. https://github.com/bitnami/charts/blob/9acd313bffb76611d3364b94ed0a7d7e611990d9/bitnami/mariadb/values.yaml#L1115

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](../RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
