### PR TITLE
[velero] feat(issue-584): Adds ImagePullSecrets to Velero server ServiceAccount

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.13.2
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 6.5.0
+version: 6.6.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/serviceaccount-server.yaml
+++ b/charts/velero/templates/serviceaccount-server.yaml
@@ -16,4 +16,10 @@ metadata:
 {{- with .Values.serviceAccount.server.labels }}
   {{- toYaml . | nindent 4 }}
 {{- end }}
+{{- if .Values.serviceAccount.server.imagePullSecrets }}
+  imagePullSecrets:
+  {{- range .Values.serviceAccount.server.imagePullSecrets }}
+    - name: {{ . }}
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -485,6 +485,8 @@ serviceAccount:
     name:
     annotations:
     labels:
+    imagePullSecrets: []
+    # - registrySecretName
 
 # Info about the secret to be used by the Velero deployment, which
 # should contain credentials for the cloud provider IAM account you've


### PR DESCRIPTION
#### Special notes for your reviewer:
Small fix that allows for use of private registries when using velero datamover.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
