### PR TITLE
[velero] add extraArgs to Velero node agent configuration

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.14.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 7.0.0
+version: 7.1.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/node-agent-daemonset.yaml
+++ b/charts/velero/templates/node-agent-daemonset.yaml
@@ -109,6 +109,9 @@ spec:
             - --log-format={{ . }}
             {{- end }}
           {{- end }}
+          {{- with .Values.nodeAgent.extraArgs }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             {{- if .Values.credentials.useSecret }}
             - name: cloud-credentials

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -560,6 +560,10 @@ nodeAgent:
   # Key/value pairs to be used as environment variables for the node-agent daemonset. Optional.
   extraEnvVars: {}
 
+  # Additional command-line arguments that will be passed to the node-agent. Optional.
+  # e.g.: extraArgs: ["--foo=bar"]
+  extraArgs: []
+
   # Configure the dnsPolicy of the node-agent daemonset
   # See: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
   dnsPolicy: ClusterFirst


### PR DESCRIPTION
#### Special notes for your reviewer:

Currently, the Helm chart does not allow passing command line parameters such as `--data-mover-prepare-timeout=1h` to the node agent, if I see correctly. This PR adds this option.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
