### PR TITLE
[velero]: add template for generating node-agent with prefix of release name 

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,11 +3,11 @@ appVersion: 1.14.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 7.1.0
+version: 7.2.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:
-- https://github.com/vmware-tanzu/velero
+  - https://github.com/vmware-tanzu/velero
 maintainers:
   - name: jenting
     email: hsiaoairplane@gmail.com

--- a/charts/velero/templates/_helpers.tpl
+++ b/charts/velero/templates/_helpers.tpl
@@ -68,7 +68,7 @@ Create the Velero priority class name.
 Create the name of the node agent.
 */}}
 {{- define "velero.nodeAgent" -}}
-  {{ default (printf "%s-%s" (include "velero.fullname" .) "node-agent") .Values.serviceAccount.server.name }}
+  {{ printf "%s-%s" (include "velero.fullname" .) "node-agent" }}
 {{- end -}}
 
 {{/*

--- a/charts/velero/templates/_helpers.tpl
+++ b/charts/velero/templates/_helpers.tpl
@@ -65,6 +65,13 @@ Create the Velero priority class name.
 {{- end -}}
 
 {{/*
+Create the name of the node agent.
+*/}}
+{{- define "velero.nodeAgent" -}}
+  {{ default (printf "%s-%s" (include "velero.fullname" .) "node-agent") .Values.serviceAccount.server.name }}
+{{- end -}}
+
+{{/*
 Create the node-Agent priority class name.
 */}}
 {{- define "velero.nodeAgent.priorityClassName" -}}

--- a/charts/velero/templates/node-agent-daemonset.yaml
+++ b/charts/velero/templates/node-agent-daemonset.yaml
@@ -4,7 +4,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: node-agent
+  name: {{ include "velero.nodeAgent" . }}
   namespace: {{ .Release.Namespace }}
   {{- with .Values.nodeAgent.annotations }}
   annotations:


### PR DESCRIPTION
#### Special notes for your reviewer:

When installing velero as a part of an umbrella helm the node-agent daemonset name does not respect the helm release name as it is hard coded in the template definition. 

This makes the lineage of the `node-agent` daemonset unclear.

i.e.
```bash
$ kubectl get po -n my-release -o name
pod/my-release-velero-b5c66b7d6-lj6l9
pod/node-agent-bqf78
```

This PR adds a template which prefixes the release name on the `node-agent` daemonset to be consistent with the velero deployment naming scheme


#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
