### PR TITLE
[velero] Fix maintenance Job resource requests

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,11 +3,11 @@ appVersion: 1.14.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 7.1.3
+version: 7.1.4
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:
-- https://github.com/vmware-tanzu/velero
+  - https://github.com/vmware-tanzu/velero
 maintainers:
   - name: jenting
     email: hsiaoairplane@gmail.com

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -169,10 +169,10 @@ spec:
             {{- with .repositoryMaintenanceJob }}
             {{- with .requests }}
             {{- with .cpu }}
-            - --maintenance-job-cpu-request={{ .cpu }}
+            - --maintenance-job-cpu-request={{ . }}
             {{- end }}
             {{- with .memory }}
-            - --maintenance-job-mem-request={{ .memory }}
+            - --maintenance-job-mem-request={{ . }}
             {{- end }}
             {{- end }}
             {{- with .limits }}


### PR DESCRIPTION
As written, the chart tries to access `.configuration.repositoryMaintenanceJob.requests.cpu.cpu` and `...memory.memory`, which leads to an error if you actually try to set these values:

```bash
$ helm template velero/velero --version 7.1.2 --set configuration.repositoryMaintenanceJob.requests.cpu=100m
Error: template: velero/templates/deployment.yaml:172:47: executing "velero/templates/deployment.yaml" at <.cpu>: can't evaluate field cpu in type string

Use --debug flag to render out invalid YAML
```
 The `limits` values do not have this issue; only the requests.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
