### PR TITLE
[velero] fix: render schedule annotations only if present in values

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.14.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 7.1.5
+version: 7.1.6
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/schedule.yaml
+++ b/charts/velero/templates/schedule.yaml
@@ -5,8 +5,8 @@ kind: Schedule
 metadata:
   name: {{ include "velero.fullname" $ }}-{{ $scheduleName }}
   namespace: {{ $.Release.Namespace }}
-  annotations:
   {{- if $schedule.annotations }}
+  annotations:
     {{- toYaml $schedule.annotations | nindent 4 }}
   {{- end }}
   labels:


### PR DESCRIPTION
#### Special notes for your reviewer:

The `charts/velero/templates/schedule.yaml` will always render the annotations section even if there is no values defined, which will bring following meaningless result:

```diff
kind: Schedule
metadata:	
+  annotations: null
```

And many tools like argo-cd will treat it as diff, so we should only render annotations only if present in values.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
