### PR TITLE
[velero] fix: consistent node-agent podLabels

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.15.2
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 8.3.0
+version: 8.4.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/node-agent-daemonset.yaml
+++ b/charts/velero/templates/node-agent-daemonset.yaml
@@ -30,8 +30,8 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         helm.sh/chart: {{ include "velero.chart" . }}
-      {{- if .Values.podLabels }}
-        {{- toYaml .Values.podLabels | nindent 8 }}
+      {{- if .Values.nodeAgent.podLabels }}
+        {{- toYaml .Values.nodeAgent.podLabels | nindent 8 }}
       {{- end }}
     {{- if or .Values.podAnnotations .Values.metrics.enabled (and .Values.credentials.useSecret (not .Values.credentials.existingSecret)) }}
       annotations:

--- a/charts/velero/templates/podmonitor.yaml
+++ b/charts/velero/templates/podmonitor.yaml
@@ -27,7 +27,7 @@ spec:
       app.kubernetes.io/name: {{ include "velero.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       name: node-agent
-    {{- with .Values.nodeAgent.labels }}
+    {{- with .Values.nodeAgent.podLabels }}
       {{- toYaml . | nindent 6 }}
     {{- end }}
   podMetricsEndpoints:

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -557,6 +557,10 @@ nodeAgent:
   # labels to set for the node-agent daemonset. Optional.
   labels: {}
 
+  # Additional pod labels for the node-agent daemonset. Optional
+  # ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels: {}
+
   # will map /scratch to emptyDir. Set to false and specify your own volume
   # via extraVolumes and extraVolumeMounts that maps to /scratch
   # if you don't want to use emptyDir.


### PR DESCRIPTION
Hello,

The node-agent was using ".Values.podLabels" in the DaemonSet while using ".Values.nodeAgent.labels" in the podMonitor.

This led to an inconsistency and made it impossible to have different labels for the node-agent compared to the Velero deployment.

Best Regards.