### PR TITLE
[velero] Add version label to deployment

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.14.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 7.2.1
+version: 7.2.2
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.14.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 7.2.0
+version: 7.2.1
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -13,6 +13,7 @@ metadata:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     helm.sh/chart: {{ include "velero.chart" . }}
     component: velero
     {{- with .Values.labels }}
@@ -36,6 +37,7 @@ spec:
         app.kubernetes.io/name: {{ include "velero.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
         helm.sh/chart: {{ include "velero.chart" . }}
         {{- if .Values.podLabels }}
           {{- toYaml .Values.podLabels | nindent 8 }}

--- a/charts/velero/templates/schedule.yaml
+++ b/charts/velero/templates/schedule.yaml
@@ -5,8 +5,8 @@ kind: Schedule
 metadata:
   name: {{ include "velero.fullname" $ }}-{{ $scheduleName }}
   namespace: {{ $.Release.Namespace }}
-  annotations:
   {{- if $schedule.annotations }}
+  annotations:
     {{- toYaml $schedule.annotations | nindent 4 }}
   {{- end }}
   labels:


### PR DESCRIPTION
#### Special notes for your reviewer:
This PR adds the Kubernetes-recommended label "app.kubernetes.io/version" to the Deployment and its Pods.
https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels

The value of the version label:

> The current version of the application (e.g., a [SemVer 1.0](https://semver.org/spec/v1.0.0.html), revision hash, etc.)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
