### PR TITLE
Velero fix node-agent daemonset annotations

### DIFF
--- a/charts/velero/templates/node-agent-daemonset.yaml
+++ b/charts/velero/templates/node-agent-daemonset.yaml
@@ -6,10 +6,6 @@ kind: DaemonSet
 metadata:
   name: node-agent
   namespace: {{ .Release.Namespace }}
-  {{- with .Values.nodeAgent.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -33,9 +29,9 @@ spec:
       {{- if .Values.podLabels }}
         {{- toYaml .Values.podLabels | nindent 8 }}
       {{- end }}
-    {{- if or .Values.podAnnotations .Values.metrics.enabled (and .Values.credentials.useSecret (not .Values.credentials.existingSecret)) }}
+    {{- if or .Values.nodeAgent.annotations .Values.metrics.enabled (and .Values.credentials.useSecret (not .Values.credentials.existingSecret)) }}
       annotations:
-      {{- with .Values.podAnnotations }}
+      {{- with .Values.nodeAgent.annotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if and (.Values.metrics.enabled) (not .Values.metrics.nodeAgentPodMonitor.enabled) }}


### PR DESCRIPTION
#### Special notes for your reviewer:
Fixes https://github.com/vmware-tanzu/helm-charts/issues/643

I'm not sure if removing `.Values.nodeAgent.annotations` from node agent daemonset metadata has any undesired effects. Im no wa an expert of this project. Important change that fixes the issue is changing template annotations from `.Values.podAnnotations` to `.Values.nodeAgent.annotations`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
