### PR TITLE
[velero] add runtimeClassName for pod.spec.runtimeClassName

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: 1.15.2.1
+appVersion: 1.15.2
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 8.7.0
+version: 8.7.1
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.15.2
+appVersion: 1.15.2.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -68,6 +68,9 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ include "velero.priorityClassName" . }}
       {{- end }}
+      {{- if .Values.runtimeClassName }}
+      runtimeClassName: {{ include "velero.runtimeClassName" . }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       containers:
         - name: velero

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -133,6 +133,9 @@ lifecycle: {}
 # Pod priority class name to use for the Velero deployment. Optional.
 priorityClassName: ""
 
+# Pod runtime class name to use for the Velero deployment. Optional.
+runtimeClassName: ""
+
 # The number of seconds to allow for graceful termination of the pod. Optional.
 terminationGracePeriodSeconds: 3600
 


### PR DESCRIPTION
#### Special notes for your reviewer:
this PR add support for `pod.spec.runtimeClass` field support of velero deployment
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
