### PR TITLE
[velero] Correct indent of dnsConfig in daemonset

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.15.2
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 8.7.1
+version: 8.7.2
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/node-agent-daemonset.yaml
+++ b/charts/velero/templates/node-agent-daemonset.yaml
@@ -203,10 +203,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.nodeAgent.dnsConfig }}
-    dnsConfig:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- with .Values.nodeAgent.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   {{- with .Values.nodeAgent.updateStrategy }}
   updateStrategy:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
#### Special notes for your reviewer:

Indendation of the dnsConfig was wrong. Should be on the same level as dnsPolicy.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
