### PR TITLE
[velero] fix: Add missing helper for .Values.runtimeClassName

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.16.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 9.0.1
+version: 9.0.2
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/_helpers.tpl
+++ b/charts/velero/templates/_helpers.tpl
@@ -65,6 +65,17 @@ Create the Velero priority class name.
 {{- end -}}
 
 {{/*
+Create the Velero runtime class name.
+*/}}
+{{- define "velero.runtimeClassName" -}}
+{{- if .Values.runtimeClassName -}}
+  {{- .Values.runtimeClassName -}}
+{{- else -}}
+  {{- include "velero.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the node-Agent priority class name.
 */}}
 {{- define "velero.nodeAgent.priorityClassName" -}}


### PR DESCRIPTION
#### Special notes for your reviewer:
This PR fix a missing helper for `.Values.runtimeClass`, this new fields was implemented in https://github.com/vmware-tanzu/helm-charts/pull/656

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
