### PR TITLE
[velero] add runtimeClassName for node-agent

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.16.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 9.0.2
+version: 9.0.3
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/_helpers.tpl
+++ b/charts/velero/templates/_helpers.tpl
@@ -87,6 +87,17 @@ Create the node-Agent priority class name.
 {{- end -}}
 
 {{/*
+Create the node-Agent runtime class name.
+*/}}
+{{- define "velero.nodeAgent.runtimeClassName" -}}
+{{- if .Values.nodeAgent.runtimeClassName -}}
+  {{- .Values.nodeAgent.runtimeClassName -}}
+{{- else -}}
+  {{- include "velero.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Kubernetes version
 Built-in object .Capabilities.KubeVersion.Minor can provide non-number output
 For examples:

--- a/charts/velero/templates/node-agent-daemonset.yaml
+++ b/charts/velero/templates/node-agent-daemonset.yaml
@@ -63,6 +63,9 @@ spec:
       {{- if .Values.nodeAgent.priorityClassName }}
       priorityClassName: {{ include "velero.nodeAgent.priorityClassName" . }}
       {{- end }}
+      {{- if .Values.runtimeClassName }}
+      runtimeClassName: {{ include "velero.nodeAgent.runtimeClassName" . }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       volumes:
         {{- if .Values.credentials.useSecret }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -544,6 +544,8 @@ nodeAgent:
   pluginVolumePath: /var/lib/kubelet/plugins
   # Pod priority class name to use for the node-agent daemonset. Optional.
   priorityClassName: ""
+  # Pod runtime class name to use for the node-agent daemonset. Optional.
+  runtimeClassName: ""
   # Resource requests/limits to specify for the node-agent daemonset deployment. Optional.
   # https://velero.io/docs/v1.6/customize-installation/#customize-resource-requests-and-limits
   resources: {}


### PR DESCRIPTION
#### Special notes for your reviewer:
This PR add support for pod.spec.runtimeClass field support of velero node-agent

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
