### PR TITLE
[velero] remove qiuming-best from maintainers

### DIFF
--- a/.github/auto-assignees.yml
+++ b/.github/auto-assignees.yml
@@ -11,7 +11,6 @@ reviewers:
     maintainers:
       - jenting
       - reasonerjt
-      - qiuming-best
       - ywk253100
 
 options:


### PR DESCRIPTION
#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [ ] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
