### PR TITLE
[velero] fix crd: creationTimestamp expected string, but got null

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.16.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 9.0.3
+version: 9.0.4
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/crds/backuprepositories.yaml
+++ b/charts/velero/crds/backuprepositories.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-  creationTimestamp: null
   labels:
     component: velero
   name: backuprepositories.velero.io

--- a/charts/velero/crds/backups.yaml
+++ b/charts/velero/crds/backups.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-  creationTimestamp: null
   labels:
     component: velero
   name: backups.velero.io

--- a/charts/velero/crds/backupstoragelocations.yaml
+++ b/charts/velero/crds/backupstoragelocations.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-  creationTimestamp: null
   labels:
     component: velero
   name: backupstoragelocations.velero.io

--- a/charts/velero/crds/datadownloads.yaml
+++ b/charts/velero/crds/datadownloads.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-  creationTimestamp: null
   labels:
     component: velero
   name: datadownloads.velero.io

--- a/charts/velero/crds/datauploads.yaml
+++ b/charts/velero/crds/datauploads.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-  creationTimestamp: null
   labels:
     component: velero
   name: datauploads.velero.io

--- a/charts/velero/crds/deletebackuprequests.yaml
+++ b/charts/velero/crds/deletebackuprequests.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-  creationTimestamp: null
   labels:
     component: velero
   name: deletebackuprequests.velero.io

--- a/charts/velero/crds/downloadrequests.yaml
+++ b/charts/velero/crds/downloadrequests.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-  creationTimestamp: null
   labels:
     component: velero
   name: downloadrequests.velero.io

--- a/charts/velero/crds/podvolumebackups.yaml
+++ b/charts/velero/crds/podvolumebackups.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-  creationTimestamp: null
   labels:
     component: velero
   name: podvolumebackups.velero.io

--- a/charts/velero/crds/podvolumerestores.yaml
+++ b/charts/velero/crds/podvolumerestores.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-  creationTimestamp: null
   labels:
     component: velero
   name: podvolumerestores.velero.io

--- a/charts/velero/crds/restores.yaml
+++ b/charts/velero/crds/restores.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-  creationTimestamp: null
   labels:
     component: velero
   name: restores.velero.io

--- a/charts/velero/crds/schedules.yaml
+++ b/charts/velero/crds/schedules.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-  creationTimestamp: null
   labels:
     component: velero
   name: schedules.velero.io

--- a/charts/velero/crds/serverstatusrequests.yaml
+++ b/charts/velero/crds/serverstatusrequests.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-  creationTimestamp: null
   labels:
     component: velero
   name: serverstatusrequests.velero.io

--- a/charts/velero/crds/volumesnapshotlocations.yaml
+++ b/charts/velero/crds/volumesnapshotlocations.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-  creationTimestamp: null
   labels:
     component: velero
   name: volumesnapshotlocations.velero.io


### PR DESCRIPTION
#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
