### PR TITLE
[velero] allow extraEnvVars to accept all formats of environment variable declaration

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.16.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 9.1.2
+version: 9.1.3
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -259,10 +259,7 @@ spec:
               value: /credentials/cloud
           {{- end }}
           {{- with .Values.configuration.extraEnvVars }}
-          {{- range $key, $value := . }}
-            - name: {{ default "none" $key }}
-              value: {{ tpl (default "none" $value) $ | quote }}
-          {{- end }}
+          {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.credentials.extraEnvVars }}
           {{- range $key, $value := . }}

--- a/charts/velero/templates/node-agent-daemonset.yaml
+++ b/charts/velero/templates/node-agent-daemonset.yaml
@@ -165,10 +165,7 @@ spec:
               value: /credentials/cloud
           {{- end }}
           {{- with .Values.configuration.extraEnvVars }}
-          {{- range $key, $value := . }}
-            - name: {{ default "none" $key }}
-              value: {{ tpl (default "none" $value) $ | quote }}
-          {{- end }}
+          {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.credentials.extraEnvVars }}
           {{- range $key, $value := . }}
@@ -180,10 +177,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- with .Values.nodeAgent.extraEnvVars }}
-          {{- range $key, $value := . }}
-            - name: {{ default "none" $key }}
-              value: {{ default "none" $value | quote }}
-          {{- end }}
+          {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if .Values.lifecycle }}
           lifecycle: {{ toYaml .Values.nodeAgent.lifecycle | nindent 12 }}

--- a/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
@@ -96,10 +96,7 @@ spec:
           {{- if (.Values.upgradeCRDsJob).extraEnvVars }}
           env:
           {{- with .Values.upgradeCRDsJob.extraEnvVars }}
-          {{- range $key, $value := . }}
-            - name: {{ default "none" $key }}
-              value: {{ default "none" $value | quote }}
-          {{- end }}
+          {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
       volumes:

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -94,8 +94,18 @@ upgradeCRDsJob:
   extraVolumes: []
   # Extra volumeMounts for the Upgrade CRDs Job. Optional.
   extraVolumeMounts: []
-  # Extra key/value pairs to be used as environment variables. Optional.
-  extraEnvVars: {}
+  # Additional values to be used as environment variables. Optional.
+  extraEnvVars: []
+    # Simple value
+    # - name: SIMPLE_VAR
+    #   value: "simple-value"
+
+    # FieldRef example
+    # - name: MY_POD_LABEL
+    #   valueFrom:
+    #     fieldRef:
+    #       fieldPath: metadata.labels['my_label']
+
   # Configure if API credential for Service Account is automounted.
   automountServiceAccountToken: true
   # Configure the shell cmd in case you are using custom image
@@ -470,8 +480,17 @@ configuration:
   # e.g.: extraArgs: ["--foo=bar"]
   extraArgs: []
 
-  # additional key/value pairs to be used as environment variables such as "AWS_CLUSTER_NAME: 'yourcluster.domain.tld'"
-  extraEnvVars: {}
+  # Additional values to be used as environment variables. Optional.
+  extraEnvVars: []
+    # Simple value
+    # - name: SIMPLE_VAR
+    #   value: "simple-value"
+
+    # FieldRef example
+    # - name: MY_POD_LABEL
+    #   valueFrom:
+    #     fieldRef:
+    #       fieldPath: metadata.labels['my_label']
 
   # Set true for backup all pod volumes without having to apply annotation on the pod when used file system backup Default: false.
   defaultVolumesToFsBackup:
@@ -590,8 +609,17 @@ nodeAgent:
   # Extra volumeMounts for the node-agent daemonset. Optional.
   extraVolumeMounts: []
 
-  # Key/value pairs to be used as environment variables for the node-agent daemonset. Optional.
-  extraEnvVars: {}
+  # Additional values to be used as environment variables for node-agent daemonset. Optional.
+  extraEnvVars: []
+    # Simple key/value
+    # - name: SIMPLE_VAR
+    #   value: "simple-value"
+
+    # FieldRef example
+    # - name: MY_POD_LABEL
+    #   valueFrom:
+    #     fieldRef:
+    #       fieldPath: metadata.labels['my_label']
 
   # Additional command-line arguments that will be passed to the node-agent. Optional.
   # e.g.: extraArgs: ["--foo=bar"]


### PR DESCRIPTION
#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)

This PR aims to resolve https://github.com/vmware-tanzu/helm-charts/issues/633
This PR contains the following changes:
- Updated values.yaml to accept list as input for extraEnvVars instead of key/value dictionary. This will allow user to input environment variables in all accepted formats by kubernetes
- Templates modified to accommodate the new input type for extraEnvVars
