### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Kubernetes Helm Charts for VMWare-Tanzu
+# Kubernetes Helm Charts for VMware-Tanzu
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![](https://github.com/vmware-tanzu/helm-charts/workflows/Release%20Charts/badge.svg?branch=main)](https://github.com/vmware-tanzu/helm-charts/actions)


### PR DESCRIPTION
Corrected VMware spelling on the front page

As an X VMware employee, it still hurts my eyes, seeing the name spelled wrong.
So just a minor change, to the front page Readme.