### PR TITLE
[Velero] Add traffic policy and type for metrics service

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.16.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 10.0.1
+version: 10.0.2
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/service.yaml
+++ b/charts/velero/templates/service.yaml
@@ -17,10 +17,19 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  type: ClusterIP
+  {{- if .Values.metrics.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.metrics.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- if .Values.metrics.service.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ .Values.metrics.service.internalTrafficPolicy }}
+  {{- end }}
+  type: {{ .Values.metrics.service.type }}
   ports:
     - name: http-monitoring
       port: 8085
+      {{- if ( and (eq .Values.metrics.service.type "NodePort" ) (not (empty .Values.metrics.service.nodePort)) ) }}
+      nodePort: {{ .Values.metrics.service.nodePort }}
+      {{- end }}
       targetPort: http-monitoring
   selector:
     name: velero

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -238,7 +238,14 @@ metrics:
   # service metdata if metrics are enabled
   service:
     annotations: {}
+    type: ClusterIP
     labels: {}
+    nodePort: null
+
+    # External/Internal traffic policy setting (Cluster, Local)
+    # https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-policies
+    externalTrafficPolicy: ""
+    internalTrafficPolicy: ""
 
   # Pod annotations for Prometheus
   podAnnotations:


### PR DESCRIPTION
#### Special notes for your reviewer:
Adding traffic policy to metrics service with External/Internal setting and service type with ClusterIP/NodePort, this feature is very helpful if monitoring metrics  is from a different cluster.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
