### PR TITLE
[velero] Fix syntax bug in deployment and service account

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.16.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 10.0.2
+version: 10.0.3
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.16.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 10.0.1
+version: 10.0.2
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
       {{- end }}
     {{- end }}
     spec:
-      {{ with .Values.hostAliases -}}
+      {{- with .Values.hostAliases -}}
       hostAliases:
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/velero/templates/serviceaccount-server.yaml
+++ b/charts/velero/templates/serviceaccount-server.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 {{- if .Values.serviceAccount.server.annotations }}
   annotations:
-{{ toYaml .Values.serviceAccount.server.annotations | nindent 4 }}
+{{- toYaml .Values.serviceAccount.server.annotations | nindent 4 }}
 {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}

--- a/charts/velero/templates/upgrade-crds/serviceaccount-upgrade.yaml
+++ b/charts/velero/templates/upgrade-crds/serviceaccount-upgrade.yaml
@@ -9,7 +9,7 @@ metadata:
     "helm.sh/hook-weight": "-4"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 {{- if .Values.serviceAccount.server.annotations }}
-{{ toYaml .Values.serviceAccount.server.annotations | nindent 4 }}
+{{- toYaml .Values.serviceAccount.server.annotations | nindent 4 }}
 {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}


### PR DESCRIPTION
#### Special notes for your reviewer:
In serviceaccount and deployment there are extra space : 

```
HOOKS:
---
# Source: velero/templates/upgrade-crds/serviceaccount-upgrade.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: velero-server-upgrade-crds
  namespace: velero
  annotations:
    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
    "helm.sh/hook-weight": "-4"
    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

    cluster: dev
  labels:
    app.kubernetes.io/name: velero
    app.kubernetes.io/instance: velero
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: velero-10.0.1
automountServiceAccountToken: true
---
```

```
MANIFEST:
---
# Source: velero/templates/serviceaccount-server.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: velero-server
  namespace: velero
  annotations:

    cluster: dev
  labels:
    app.kubernetes.io/name: velero
    app.kubernetes.io/instance: velero
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: velero-10.0.1
automountServiceAccountToken: true
---
# Source: velero/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: velero
  namespace: velero
  labels:
    app.kubernetes.io/name: velero
    app.kubernetes.io/instance: velero
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/version: 1.16.0
    helm.sh/chart: velero-10.0.1
    component: velero
spec:
  replicas: 1
  strategy:
    type: Recreate
  selector:
    matchLabels:
      app.kubernetes.io/instance: velero
      app.kubernetes.io/name: velero
  template:
    metadata:
      labels:
        name: velero
        app.kubernetes.io/name: velero
        app.kubernetes.io/instance: velero
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/version: 1.16.0
        helm.sh/chart: velero-10.0.1
    spec:

      restartPolicy: Always
 
```
which will potentially cause failure to add custom values.

fix issue : [Annotations are not added into serviceaccount during helm deployment](https://github.com/vmware-tanzu/helm-charts/issues/666)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
