### PR TITLE
[velero] Allow configure specify clusterIP and generate nodePort port

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.16.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 10.0.4
+version: 10.0.5
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/service.yaml
+++ b/charts/velero/templates/service.yaml
@@ -17,6 +17,9 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if .Values.metrics.service.clusterIP }}
+  clusterIP: {{ .Values.metrics.service.clusterIP }}
+  {{- end }}
   {{- if .Values.metrics.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.metrics.service.externalTrafficPolicy }}
   {{- end }}
@@ -27,7 +30,7 @@ spec:
   ports:
     - name: http-monitoring
       port: 8085
-      {{- if ( and (eq .Values.metrics.service.type "NodePort" ) (not (empty .Values.metrics.service.nodePort)) ) }}
+      {{- if .Values.metrics.service.nodePort }}
       nodePort: {{ .Values.metrics.service.nodePort }}
       {{- end }}
       targetPort: http-monitoring

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -240,7 +240,13 @@ metrics:
     annotations: {}
     type: ClusterIP
     labels: {}
-    nodePort: null
+
+    # Configure specify cluster IP for service type is ClusterIP
+    # https://kubernetes.io/docs/concepts/services-networking/service/#type-clusterip
+    clusterIP: ""
+    # Configure specify node port for service type is NodePort
+    # https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+    nodePort: ""
 
     # External/Internal traffic policy setting (Cluster, Local)
     # https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-policies


### PR DESCRIPTION
#### Special notes for your reviewer:
Allow users to specify the clusterIP port and allow nodePort to generate a port number if users do not fill value in nodePort.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [ ] Variables are documented in the values.yaml or README.md
- [ ] Title of the PR starts with chart name (e.g. `[velero]`)
