### PR TITLE
[velero] Fix syntax bug in hostAliases

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.16.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 10.0.5
+version: 10.0.6
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.16.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 10.0.4
+version: 10.0.5
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
       {{- end }}
     {{- end }}
     spec:
-      {{- with .Values.hostAliases -}}
+      {{- with .Values.hostAliases }}
       hostAliases:
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/velero/templates/node-agent-daemonset.yaml
+++ b/charts/velero/templates/node-agent-daemonset.yaml
@@ -49,7 +49,7 @@ spec:
       {{- end }}
     {{- end }}
     spec:
-      {{- with .Values.hostAliases }}
+      {{- with .Values.nodeAgent.hostAliases }}
       hostAliases:
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/velero/templates/node-agent-daemonset.yaml
+++ b/charts/velero/templates/node-agent-daemonset.yaml
@@ -49,7 +49,7 @@ spec:
       {{- end }}
     {{- end }}
     spec:
-      {{ with .Values.hostAliases -}}
+      {{- with .Values.hostAliases }}
       hostAliases:
       {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
#### Special notes for your reviewer:
I'm having issues when adding and not adding `hostAliases` :
In the case of not adding `hostAliases` there is extra space on `node-agent daemonset` :
```
        name: node-agent
        role: node-agent
        app.kubernetes.io/name: velero
        app.kubernetes.io/instance: velero
        app.kubernetes.io/managed-by: Helm
        helm.sh/chart: velero-10.0.4
      annotations:
        prometheus.io/path: /metrics
        prometheus.io/port: "8085"
        prometheus.io/scrape: "true"
    spec:

      serviceAccountName: velero-server
      automountServiceAccountToken: true
```
And in the case of adding `hostAliases` there is error on `velero deployment` :
`YAML parse error on velero/templates/deployment.yaml: error converting YAML to JSON: yaml: line 35: did not find expected key`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
