### PR TITLE
[velero] feat: Added support for dual-stack for the metrics service

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.16.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 10.0.8
+version: 10.0.9
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/service.yaml
+++ b/charts/velero/templates/service.yaml
@@ -23,6 +23,12 @@ spec:
   {{- if .Values.metrics.service.internalTrafficPolicy }}
   internalTrafficPolicy: {{ .Values.metrics.service.internalTrafficPolicy }}
   {{- end }}
+  {{- if .Values.metrics.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.metrics.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.metrics.service.ipFamilies }}
+  ipFamilies: {{ toYaml .Values.metrics.service.ipFamilies | nindent 4 }}
+  {{- end }}
   type: {{ .Values.metrics.service.type }}
   ports:
     - name: http-monitoring

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -247,6 +247,11 @@ metrics:
     externalTrafficPolicy: ""
     internalTrafficPolicy: ""
 
+    # the IP family policy for the metrics Service to be able to configure dual-stack; see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services).
+    ipFamilyPolicy: ""
+    # a list of IP families for the metrics Service that should be supported, in the order in which they should be applied to ClusterIP. Can be "IPv4" and/or "IPv6".
+    ipFamilies: []
+
   # Pod annotations for Prometheus
   podAnnotations:
     prometheus.io/scrape: "true"


### PR DESCRIPTION
#### Special notes for your reviewer:

Adding support for configuring dual stack for the metrics service.
The default behavior shouldn't change.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
