### PR TITLE
[velero] Update example PrometheusRule

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.16.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 10.0.10
+version: 10.0.11
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -296,19 +296,40 @@ metrics:
     # namespace: ""
     # Rules to be deployed
     spec: []
-    # - alert: VeleroBackupPartialFailures
+    # - alert: VeleroBackupFailed
     #   annotations:
-    #     message: Velero backup {{ $labels.schedule }} has {{ $value | humanizePercentage }} partialy failed backups.
+    #     message: Velero backup {{ $labels.schedule }} has failed
     #   expr: |-
-    #     velero_backup_partial_failure_total{schedule!=""} / velero_backup_attempt_total{schedule!=""} > 0.25
+    #     velero_backup_last_status{schedule!=""} != 1
     #   for: 15m
     #   labels:
     #     severity: warning
-    # - alert: VeleroBackupFailures
+    # - alert: VeleroBackupFailing
     #   annotations:
-    #     message: Velero backup {{ $labels.schedule }} has {{ $value | humanizePercentage }} failed backups.
+    #     message: Velero backup {{ $labels.schedule }} has been failing for the last 12h
     #   expr: |-
-    #     velero_backup_failure_total{schedule!=""} / velero_backup_attempt_total{schedule!=""} > 0.25
+    #     velero_backup_last_status{schedule!=""} != 1
+    #   for: 12h
+    #   labels:
+    #     severity: critical
+    # - alert: VeleroNoNewBackup
+    #   annotations:
+    #     message: Velero backup {{ $labels.schedule }} has not run successfuly in the last 30h
+    #   expr: |-
+    #     (
+    #     rate(velero_backup_last_successful_timestamp{schedule!=""}[15m]) <=bool 0
+    #     or
+    #     absent(velero_backup_last_successful_timestamp{schedule!=""})
+    #     ) == 1
+    #   for: 30h
+    #   labels:
+    #     severity: critical
+    # - alert: VeleroBackupPartialFailures
+    #   annotations:
+    #     message: Velero backup {{ $labels.schedule }} has {{ $value | humanizePercentage }} partialy failed backups
+    #   expr: |-
+    #     rate(velero_backup_partial_failure_total{schedule!=""}[25m])
+    #       / rate(velero_backup_attempt_total{schedule!=""}[25m]) > 0.5
     #   for: 15m
     #   labels:
     #     severity: warning


### PR DESCRIPTION
The provided example shall never be one that gives false negatives on the subject of whether a backup is failing. The consequences may be catastrophic if someone does not notice it is an absolutely horrible example that is giving a false sense of security.

It would be better to remove the example altogether than to provide one that can keep claiming everything is in order when there is a chain of failed backups instead.

If it is impossible to include mine / another one that actually works, please remove the bad example that the helm chart's `values.yaml` currently provides

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines) -> N/A, updated code that is commented out
- [x] Variables are documented in the values.yaml or README.md -> N/A, updated code that is commented out
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
