### PR TITLE
[velero] Update kubectl image repository from bitnami to registry.k8s.io

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.16.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 10.0.10
+version: 10.0.11
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.16.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 10.0.11
+version: 11.0.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/_helpers.tpl
+++ b/charts/velero/templates/_helpers.tpl
@@ -99,14 +99,10 @@ Create the node-Agent runtime class name.
 
 {{/*
 Kubernetes version
-Built-in object .Capabilities.KubeVersion.Minor can provide non-number output
-For examples:
-- on GKE it returns "18+" instead of "18"
-- on EKS it returns "20+" instead of "20"
 */}}
 {{- define "chart.KubernetesVersion" -}}
-{{- $minorVersion := .Capabilities.KubeVersion.Minor | regexFind "[0-9]+" -}}
-{{- printf "%s.%s" .Capabilities.KubeVersion.Major $minorVersion -}}
+{{- $version := .Capabilities.KubeVersion.Version | regexFind "v[0-9]+\\.[0-9]+\\.[0-9]+" -}}
+{{- printf "%s" $version -}}
 {{- end -}}
 
 

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -315,12 +315,12 @@ metrics:
 
 kubectl:
   image:
-    repository: docker.io/bitnami/kubectl
-    # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
+    repository: registry.k8s.io/kubectl
+    # Digest value example: sha256:23092268826ee317db2f6fb409a3c4cc30fb081c99c05c82e80f1dbc9e59d0ab.
     # If used, it will take precedence over the kubectl.image.tag.
     # digest:
     # kubectl image tag. If used, it will take precedence over the cluster Kubernetes version.
-    # tag: 1.16.15
+    # tag: v1.32.0
   # Container Level Security Context for the 'kubectl' container of the crd jobs. Optional.
   # See: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   containerSecurityContext: {}


### PR DESCRIPTION
#### Special notes for your reviewer:

This PR corresponds to issue https://github.com/vmware-tanzu/helm-charts/issues/698, and removes the use of `bitnami` kubectl image in favor of `registry.k8s.io`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [X] Title of the PR starts with chart name (e.g. `[velero]`)
