### PR TITLE
[velero] refactor labelnamespace job and values.yaml for namespace labels

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.16.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 10.0.11
+version: 10.0.12
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/label-namespace/labelnamespace.yaml
+++ b/charts/velero/templates/label-namespace/labelnamespace.yaml
@@ -31,8 +31,8 @@ spec:
         - /bin/sh
         - -c
         - |
-          {{- range .Values.namespace.labels }}
-          kubectl label namespace {{ $.Release.Namespace }} {{ .key }}={{ .value }}
+          {{- range $key, $value := .Values.namespace.labels }}
+          kubectl label namespace {{ $.Release.Namespace }} {{ $key }}={{ $value }}
           {{- end }}
         {{- if .Values.kubectl.extraVolumeMounts }}
         volumeMounts:

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -7,18 +7,12 @@ namespace:
   labels: {}
     # Enforce Pod Security Standards with Namespace Labels
     # https://kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-namespace-labels/
-    # - key: pod-security.kubernetes.io/enforce
-    #   value: privileged
-    # - key: pod-security.kubernetes.io/enforce-version
-    #   value: latest
-    # - key: pod-security.kubernetes.io/audit
-    #   value: privileged
-    # - key: pod-security.kubernetes.io/audit-version
-    #   value: latest
-    # - key: pod-security.kubernetes.io/warn
-    #   value: privileged
-    # - key: pod-security.kubernetes.io/warn-version
-    #   value: latest
+    # pod-security.kubernetes.io/enforce: privileged
+    # pod-security.kubernetes.io/enforce-version: latest
+    # pod-security.kubernetes.io/audit: privileged
+    # pod-security.kubernetes.io/audit-version: latest
+    # pod-security.kubernetes.io/warn: privileged
+    # pod-security.kubernetes.io/warn-version: latest
 
 ##
 ## End of namespace-related settings.


### PR DESCRIPTION
#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)

This PR aims to address https://github.com/vmware-tanzu/helm-charts/issues/653 and follow industry best practices as to label type fields are rendered in helm templates. It's a good practice to take labels and annotations like fields as an object instead of a list.
The values.yaml has been updated with proper examples in the commented lines to take labels for namespace as an object instead of list, which matches the format specified in values.schema.json as well. The template for `labelnamespace` job has been updated to accommodate this change in labels format.
