### PR TITLE
[velero] feat: Support in-place resource resize for containers

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.16.2
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 10.1.0
+version: 10.1.1
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -213,6 +213,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.resizePolicy }}
+          resizePolicy:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.metrics.enabled }}
           {{- with .Values.livenessProbe }}
           livenessProbe: {{- toYaml . | nindent 12 }}

--- a/charts/velero/templates/node-agent-daemonset.yaml
+++ b/charts/velero/templates/node-agent-daemonset.yaml
@@ -197,6 +197,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.nodeAgent.resizePolicy }}
+          resizePolicy:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.nodeAgent.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -75,6 +75,14 @@ resources: {}
   #   cpu: 1000m
   #   memory: 512Mi
 
+# Container resize policy for the Velero deployment.
+# See: https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/
+resizePolicy: []
+  # - resourceName: cpu
+  #   restartPolicy: NotRequired
+  # - resourceName: memory
+  #   restartPolicy: RestartContainer
+
 # Configure hostAliases for Velero deployment. Optional
 # For more information, check: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
 hostAliases: []
@@ -663,6 +671,13 @@ nodeAgent:
     # limits:
     #   cpu: 1000m
     #   memory: 1024Mi
+  # Container resize policy for the node-agent daemonset.
+  # See: https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/
+  resizePolicy: []
+    # - resourceName: cpu
+    #   restartPolicy: NotRequired
+    # - resourceName: memory
+    #   restartPolicy: RestartContainer
 
   # Tolerations to use for the node-agent daemonset. Optional.
   tolerations: []


### PR DESCRIPTION
#### Special notes for your reviewer:

Add support for container resource [resizePolicy](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/) configuration in Deployment and DaemonSet workloads. This allows users to specify how containers should handle resource limit updates (CPU/memory) without requiring pod restarts.

This feature improves workload availability by allowing in-place resource updates for compatible applications, reducing downtime during resource adjustments.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [X] Title of the PR starts with chart name (e.g. `[velero]`)
