### PR TITLE
[velero] Remove bitnami nicely by inverting the original idea

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.17.2
+appVersion: 1.17.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.18.0-rc.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 11.3.2
+version: 11.3.3
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.16.2
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 10.1.2
+version: 10.1.3
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: 1.17.1
+appVersion: 1.18.0-rc.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 11.3.0
+version: 11.3.3
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.18.0-rc.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 11.3.3
+version: 11.3.2
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.16.2
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 10.1.1
+version: 10.1.2
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: 1.17.1
+appVersion: 1.17.2
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 11.2.0
+version: 11.3.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.18.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 11.4.0
+version: 11.5.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.18.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 11.5.0
+version: 12.0.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: 1.18.0-rc.1
+appVersion: 1.18.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 11.3.3
+version: 11.4.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/crds/backuprepositories.yaml
+++ b/charts/velero/crds/backuprepositories.yaml
@@ -116,8 +116,8 @@ spec:
                       nullable: true
                       type: string
                     message:
-                      description: Message is a message about the current status
-                        of the repo maintenance.
+                      description: Message is a message about the current status of
+                        the repo maintenance.
                       type: string
                     result:
                       description: Result is the result of the repo maintenance.
@@ -126,8 +126,7 @@ spec:
                       - Failed
                       type: string
                     startTimestamp:
-                      description: StartTimestamp is the start time of the repo
-                        maintenance.
+                      description: StartTimestamp is the start time of the repo maintenance.
                       format: date-time
                       nullable: true
                       type: string

--- a/charts/velero/crds/backups.yaml
+++ b/charts/velero/crds/backups.yaml
@@ -124,8 +124,8 @@ spec:
                           nullable: true
                           type: array
                         excludedResources:
-                          description: ExcludedResources specifies the resources
-                            to which this hook spec does not apply.
+                          description: ExcludedResources specifies the resources to
+                            which this hook spec does not apply.
                           items:
                             type: string
                           nullable: true
@@ -147,8 +147,8 @@ spec:
                           nullable: true
                           type: array
                         labelSelector:
-                          description: LabelSelector, if specified, filters the
-                            resources to which this hook spec applies.
+                          description: LabelSelector, if specified, filters the resources
+                            to which this hook spec applies.
                           nullable: true
                           properties:
                             matchExpressions:
@@ -202,8 +202,7 @@ spec:
                             PostHooks is a list of BackupResourceHooks to execute after storing the item in the backup.
                             These are executed after all "additional items" from item actions are processed.
                           items:
-                            description: BackupResourceHook defines a hook for a
-                              resource.
+                            description: BackupResourceHook defines a hook for a resource.
                             properties:
                               exec:
                                 description: Exec defines an exec hook.
@@ -222,8 +221,8 @@ spec:
                                     type: string
                                   onError:
                                     description: OnError specifies how Velero should
-                                      behave if it encounters an error executing
-                                      this hook.
+                                      behave if it encounters an error executing this
+                                      hook.
                                     enum:
                                     - Continue
                                     - Fail
@@ -245,8 +244,7 @@ spec:
                             PreHooks is a list of BackupResourceHooks to execute prior to storing the item in the backup.
                             These are executed before any "additional items" from item actions are processed.
                           items:
-                            description: BackupResourceHook defines a hook for a
-                              resource.
+                            description: BackupResourceHook defines a hook for a resource.
                             properties:
                               exec:
                                 description: Exec defines an exec hook.
@@ -265,8 +263,8 @@ spec:
                                     type: string
                                   onError:
                                     description: OnError specifies how Velero should
-                                      behave if it encounters an error executing
-                                      this hook.
+                                      behave if it encounters an error executing this
+                                      hook.
                                     enum:
                                     - Continue
                                     - Fail
@@ -407,16 +405,16 @@ spec:
                     label selector matches no objects.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector
-                        requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
                         description: |-
                           A label selector requirement is a selector that contains values, a key, and an operator that
                           relates the key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector
-                              applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
                             description: |-
@@ -494,8 +492,8 @@ spec:
                 nullable: true
                 type: boolean
               storageLocation:
-                description: StorageLocation is a string containing the name of
-                  a BackupStorageLocation where the backup should be stored.
+                description: StorageLocation is a string containing the name of a
+                  BackupStorageLocation where the backup should be stored.
                 type: string
               ttl:
                 description: |-
@@ -503,8 +501,7 @@ spec:
                   the Backup should be retained for.
                 type: string
               uploaderConfig:
-                description: UploaderConfig specifies the configuration for the
-                  uploader.
+                description: UploaderConfig specifies the configuration for the uploader.
                 nullable: true
                 properties:
                   parallelFilesUpload:
@@ -513,12 +510,12 @@ spec:
                     type: integer
                 type: object
               volumeGroupSnapshotLabelKey:
-                description: VolumeGroupSnapshotLabelKey specifies the label key
-                  to group PVCs under a VGS.
+                description: VolumeGroupSnapshotLabelKey specifies the label key to
+                  group PVCs under a VGS.
                 type: string
               volumeSnapshotLocations:
-                description: VolumeSnapshotLocations is a list containing names
-                  of VolumeSnapshotLocations associated with this backup.
+                description: VolumeSnapshotLocations is a list containing names of
+                  VolumeSnapshotLocations associated with this backup.
                 items:
                   type: string
                 type: array
@@ -580,8 +577,8 @@ spec:
                   major, minor, and patch version.
                 type: string
               hookStatus:
-                description: HookStatus contains information about the status of
-                  the hooks.
+                description: HookStatus contains information about the status of the
+                  hooks.
                 nullable: true
                 properties:
                   hooksAttempted:
@@ -591,8 +588,8 @@ spec:
                       and the number of hooks that executed successfully.
                     type: integer
                   hooksFailed:
-                    description: HooksFailed is the total number of hooks which
-                      ended with an error
+                    description: HooksFailed is the total number of hooks which ended
+                      with an error
                     type: integer
                 type: object
               phase:

--- a/charts/velero/crds/backups.yaml
+++ b/charts/velero/crds/backups.yaml
@@ -596,6 +596,8 @@ spec:
                 description: Phase is the current state of the Backup.
                 enum:
                 - New
+                - Queued
+                - ReadyToStart
                 - FailedValidation
                 - InProgress
                 - WaitingForPluginOperations
@@ -627,6 +629,11 @@ spec:
                       filters that happen as items are processed.
                     type: integer
                 type: object
+              queuePosition:
+                description: |-
+                  QueuePosition is the position of the backup in the queue.
+                  Only relevant when Phase is "Queued"
+                type: integer
               startTimestamp:
                 description: |-
                   StartTimestamp records the time a backup was started.

--- a/charts/velero/crds/backupstoragelocations.yaml
+++ b/charts/velero/crds/backupstoragelocations.yaml
@@ -115,10 +115,38 @@ spec:
                     description: Bucket is the bucket to use for object storage.
                     type: string
                   caCert:
-                    description: CACert defines a CA bundle to use when verifying
-                      TLS connections to the provider.
+                    description: |-
+                      CACert defines a CA bundle to use when verifying TLS connections to the provider.
+                      Deprecated: Use CACertRef instead.
                     format: byte
                     type: string
+                  caCertRef:
+                    description: |-
+                      CACertRef is a reference to a Secret containing the CA certificate bundle to use
+                      when verifying TLS connections to the provider. The Secret must be in the same
+                      namespace as the BackupStorageLocation.
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
                   prefix:
                     description: Prefix is the path inside a bucket to use for Velero
                       storage. Optional.

--- a/charts/velero/crds/backupstoragelocations.yaml
+++ b/charts/velero/crds/backupstoragelocations.yaml
@@ -23,8 +23,8 @@ spec:
       jsonPath: .status.phase
       name: Phase
       type: string
-    - description: LastValidationTime is the last time the backup store location
-        was validated
+    - description: LastValidationTime is the last time the backup store location was
+        validated
       jsonPath: .status.lastValidationTime
       name: Last Validated
       type: date
@@ -59,8 +59,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: BackupStorageLocationSpec defines the desired state of
-              a Velero BackupStorageLocation
+            description: BackupStorageLocationSpec defines the desired state of a
+              Velero BackupStorageLocation
             properties:
               accessMode:
                 description: AccessMode defines the permissions for the backup storage
@@ -84,8 +84,8 @@ spec:
                   to be used with this location
                 properties:
                   key:
-                    description: The key of the secret to select from.  Must be
-                      a valid secret key.
+                    description: The key of the secret to select from.  Must be a
+                      valid secret key.
                     type: string
                   name:
                     default: ""
@@ -139,8 +139,8 @@ spec:
             - provider
             type: object
           status:
-            description: BackupStorageLocationStatus defines the observed state
-              of BackupStorageLocation
+            description: BackupStorageLocationStatus defines the observed state of
+              BackupStorageLocation
             properties:
               accessMode:
                 description: |-

--- a/charts/velero/crds/datadownloads.yaml
+++ b/charts/velero/crds/datadownloads.yaml
@@ -110,6 +110,10 @@ spec:
                 description: SnapshotID is the ID of the Velero backup snapshot to
                   be restored from.
                 type: string
+              snapshotSize:
+                description: SnapshotSize is the logical size in Bytes of the snapshot.
+                format: int64
+                type: integer
               sourceNamespace:
                 description: |-
                   SourceNamespace is the original namespace where the volume is backed up from.

--- a/charts/velero/crds/datadownloads.yaml
+++ b/charts/velero/crds/datadownloads.yaml
@@ -35,8 +35,7 @@ spec:
       jsonPath: .status.progress.totalBytes
       name: Total Bytes
       type: integer
-    - description: Name of the Backup Storage Location where the backup data is
-        stored
+    - description: Name of the Backup Storage Location where the backup data is stored
       jsonPath: .spec.backupStorageLocation
       name: Storage Location
       type: string
@@ -96,8 +95,7 @@ spec:
                   If DataMover is "" or "velero", the built-in data mover will be used.
                 type: string
               nodeOS:
-                description: NodeOS is OS of the node where the DataDownload is
-                  processed.
+                description: NodeOS is OS of the node where the DataDownload is processed.
                 enum:
                 - auto
                 - linux
@@ -109,8 +107,8 @@ spec:
                   before returning error as timeout.
                 type: string
               snapshotID:
-                description: SnapshotID is the ID of the Velero backup snapshot
-                  to be restored from.
+                description: SnapshotID is the ID of the Velero backup snapshot to
+                  be restored from.
                 type: string
               sourceNamespace:
                 description: |-
@@ -125,8 +123,8 @@ spec:
                     description: Namespace is the target namespace
                     type: string
                   pv:
-                    description: PV is the name of the target PV that is created
-                      by Velero restore
+                    description: PV is the name of the target PV that is created by
+                      Velero restore
                     type: string
                   pvc:
                     description: PVC is the name of the target PVC that is created
@@ -169,8 +167,7 @@ spec:
                 description: Message is a message about the DataDownload's status.
                 type: string
               node:
-                description: Node is name of the node where the DataDownload is
-                  processed.
+                description: Node is name of the node where the DataDownload is processed.
                 type: string
               phase:
                 description: Phase is the current state of the DataDownload.

--- a/charts/velero/crds/datauploads.yaml
+++ b/charts/velero/crds/datauploads.yaml
@@ -35,8 +35,8 @@ spec:
       jsonPath: .status.progress.totalBytes
       name: Total Bytes
       type: integer
-    - description: Name of the Backup Storage Location where this backup should
-        be stored
+    - description: Name of the Backup Storage Location where this backup should be
+        stored
       jsonPath: .spec.backupStorageLocation
       name: Storage Location
       type: string
@@ -51,8 +51,8 @@ spec:
     name: v2alpha1
     schema:
       openAPIV3Schema:
-        description: DataUpload acts as the protocol between data mover plugins
-          and data mover controller for the datamover backup operation
+        description: DataUpload acts as the protocol between data mover plugins and
+          data mover controller for the datamover backup operation
         properties:
           apiVersion:
             description: |-
@@ -93,8 +93,8 @@ spec:
                     description: Driver is the driver used by the VolumeSnapshotContent
                     type: string
                   snapshotClass:
-                    description: SnapshotClass is the name of the snapshot class
-                      that the volume snapshot is created with
+                    description: SnapshotClass is the name of the snapshot class that
+                      the volume snapshot is created with
                     type: string
                   storageClass:
                     description: StorageClass is the name of the storage class of
@@ -135,8 +135,8 @@ spec:
                   It is the same namespace for SourcePVC and CSI namespaced objects.
                 type: string
               sourcePVC:
-                description: SourcePVC is the name of the PVC which the snapshot
-                  is taken for.
+                description: SourcePVC is the name of the PVC which the snapshot is
+                  taken for.
                 type: string
             required:
             - backupStorageLocation
@@ -189,8 +189,8 @@ spec:
                 - windows
                 type: string
               path:
-                description: Path is the full path of the snapshot volume being
-                  backed up.
+                description: Path is the full path of the snapshot volume being backed
+                  up.
                 type: string
               phase:
                 description: Phase is the current state of the DataUpload.

--- a/charts/velero/crds/datauploads.yaml
+++ b/charts/velero/crds/datauploads.yaml
@@ -35,6 +35,12 @@ spec:
       jsonPath: .status.progress.totalBytes
       name: Total Bytes
       type: integer
+    - description: Incremental bytes
+      format: int64
+      jsonPath: .status.incrementalBytes
+      name: Incremental Bytes
+      priority: 10
+      type: integer
     - description: Name of the Backup Storage Location where this backup should be
         stored
       jsonPath: .spec.backupStorageLocation
@@ -175,6 +181,11 @@ spec:
                   as a result of the DataUpload.
                 nullable: true
                 type: object
+              incrementalBytes:
+                description: IncrementalBytes holds the number of bytes new or changed
+                  since the last backup
+                format: int64
+                type: integer
               message:
                 description: Message is a message about the DataUpload's status.
                 type: string

--- a/charts/velero/crds/deletebackuprequests.yaml
+++ b/charts/velero/crds/deletebackuprequests.yaml
@@ -48,8 +48,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: DeleteBackupRequestSpec is the specification for which
-              backups to delete.
+            description: DeleteBackupRequestSpec is the specification for which backups
+              to delete.
             properties:
               backupName:
                 type: string

--- a/charts/velero/crds/downloadrequests.yaml
+++ b/charts/velero/crds/downloadrequests.yaml
@@ -41,8 +41,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: DownloadRequestSpec is the specification for a download
-              request.
+            description: DownloadRequestSpec is the specification for a download request.
             properties:
               target:
                 description: Target is what to download (e.g. logs for a backup).
@@ -84,8 +83,8 @@ spec:
                   file.
                 type: string
               expiration:
-                description: Expiration is when this DownloadRequest expires and
-                  can be deleted by the system.
+                description: Expiration is when this DownloadRequest expires and can
+                  be deleted by the system.
                 format: date-time
                 nullable: true
                 type: string

--- a/charts/velero/crds/podvolumebackups.yaml
+++ b/charts/velero/crds/podvolumebackups.yaml
@@ -35,8 +35,8 @@ spec:
       jsonPath: .status.progress.totalBytes
       name: Total Bytes
       type: integer
-    - description: Name of the Backup Storage Location where this backup should
-        be stored
+    - description: Name of the Backup Storage Location where this backup should be
+        stored
       jsonPath: .spec.backupStorageLocation
       name: Storage Location
       type: string
@@ -91,8 +91,8 @@ spec:
                   on.
                 type: string
               pod:
-                description: Pod is a reference to the pod containing the volume
-                  to be backed up.
+                description: Pod is a reference to the pod containing the volume to
+                  be backed up.
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -153,8 +153,8 @@ spec:
                 nullable: true
                 type: object
               uploaderType:
-                description: UploaderType is the type of the uploader to handle
-                  the data transfer.
+                description: UploaderType is the type of the uploader to handle the
+                  data transfer.
                 enum:
                 - kopia
                 - restic
@@ -192,8 +192,7 @@ spec:
                 nullable: true
                 type: string
               message:
-                description: Message is a message about the pod volume backup's
-                  status.
+                description: Message is a message about the pod volume backup's status.
                 type: string
               path:
                 description: Path is the full path within the controller pod being

--- a/charts/velero/crds/podvolumebackups.yaml
+++ b/charts/velero/crds/podvolumebackups.yaml
@@ -35,6 +35,12 @@ spec:
       jsonPath: .status.progress.totalBytes
       name: Total Bytes
       type: integer
+    - description: Incremental bytes
+      format: int64
+      jsonPath: .status.incrementalBytes
+      name: Incremental Bytes
+      priority: 10
+      type: integer
     - description: Name of the Backup Storage Location where this backup should be
         stored
       jsonPath: .spec.backupStorageLocation
@@ -191,6 +197,11 @@ spec:
                 format: date-time
                 nullable: true
                 type: string
+              incrementalBytes:
+                description: IncrementalBytes holds the number of bytes new or changed
+                  since the last backup
+                format: int64
+                type: integer
               message:
                 description: Message is a message about the pod volume backup's status.
                 type: string

--- a/charts/velero/crds/podvolumerestores.yaml
+++ b/charts/velero/crds/podvolumerestores.yaml
@@ -35,8 +35,7 @@ spec:
       jsonPath: .status.progress.totalBytes
       name: Total Bytes
       type: integer
-    - description: Name of the Backup Storage Location where the backup data is
-        stored
+    - description: Name of the Backup Storage Location where the backup data is stored
       jsonPath: .spec.backupStorageLocation
       name: Storage Location
       type: string
@@ -87,8 +86,8 @@ spec:
                   when the PodVolumeRestore is in InProgress phase
                 type: boolean
               pod:
-                description: Pod is a reference to the pod containing the volume
-                  to be restored.
+                description: Pod is a reference to the pod containing the volume to
+                  be restored.
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -149,16 +148,16 @@ spec:
                 nullable: true
                 type: object
               uploaderType:
-                description: UploaderType is the type of the uploader to handle
-                  the data transfer.
+                description: UploaderType is the type of the uploader to handle the
+                  data transfer.
                 enum:
                 - kopia
                 - restic
                 - ""
                 type: string
               volume:
-                description: Volume is the name of the volume within the Pod to
-                  be restored.
+                description: Volume is the name of the volume within the Pod to be
+                  restored.
                 type: string
             required:
             - backupStorageLocation
@@ -187,8 +186,7 @@ spec:
                 nullable: true
                 type: string
               message:
-                description: Message is a message about the pod volume restore's
-                  status.
+                description: Message is a message about the pod volume restore's status.
                 type: string
               node:
                 description: Node is name of the node where the pod volume restore

--- a/charts/velero/crds/podvolumerestores.yaml
+++ b/charts/velero/crds/podvolumerestores.yaml
@@ -135,6 +135,10 @@ spec:
               snapshotID:
                 description: SnapshotID is the ID of the volume snapshot to be restored.
                 type: string
+              snapshotSize:
+                description: SnapshotSize is the logical size in Bytes of the snapshot.
+                format: int64
+                type: integer
               sourceNamespace:
                 description: SourceNamespace is the original namespace for namaspace
                   mapping.

--- a/charts/velero/crds/restores.yaml
+++ b/charts/velero/crds/restores.yaml
@@ -87,8 +87,8 @@ spec:
                           nullable: true
                           type: array
                         excludedResources:
-                          description: ExcludedResources specifies the resources
-                            to which this hook spec does not apply.
+                          description: ExcludedResources specifies the resources to
+                            which this hook spec does not apply.
                           items:
                             type: string
                           nullable: true
@@ -110,8 +110,8 @@ spec:
                           nullable: true
                           type: array
                         labelSelector:
-                          description: LabelSelector, if specified, filters the
-                            resources to which this hook spec applies.
+                          description: LabelSelector, if specified, filters the resources
+                            to which this hook spec applies.
                           nullable: true
                           properties:
                             matchExpressions:
@@ -172,8 +172,8 @@ spec:
                                 properties:
                                   command:
                                     description: Command is the command and arguments
-                                      to execute from within a container after a
-                                      pod has been restored.
+                                      to execute from within a container after a pod
+                                      has been restored.
                                     items:
                                       type: string
                                     minItems: 1
@@ -190,8 +190,8 @@ spec:
                                     type: string
                                   onError:
                                     description: OnError specifies how Velero should
-                                      behave if it encounters an error executing
-                                      this hook.
+                                      behave if it encounters an error executing this
+                                      hook.
                                     enum:
                                     - Continue
                                     - Fail
@@ -214,9 +214,8 @@ spec:
                                 description: Init defines an init restore hook.
                                 properties:
                                   initContainers:
-                                    description: InitContainers is list of init
-                                      containers to be added to a pod during its
-                                      restore.
+                                    description: InitContainers is list of init containers
+                                      to be added to a pod during its restore.
                                     items:
                                       type: object
                                       x-kubernetes-preserve-unknown-fields: true
@@ -336,16 +335,16 @@ spec:
                     label selector matches no objects.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector
-                        requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
                         description: |-
                           A label selector requirement is a selector that contains values, a key, and an operator that
                           relates the key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector
-                              applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
                             description: |-
@@ -381,8 +380,8 @@ spec:
                 nullable: true
                 type: array
               preserveNodePorts:
-                description: PreserveNodePorts specifies whether to restore old
-                  nodePorts from backup.
+                description: PreserveNodePorts specifies whether to restore old nodePorts
+                  from backup.
                 nullable: true
                 type: boolean
               resourceModifier:
@@ -442,17 +441,16 @@ spec:
                   from the most recent successful backup created from this schedule.
                 type: string
               uploaderConfig:
-                description: UploaderConfig specifies the configuration for the
-                  restore.
+                description: UploaderConfig specifies the configuration for the restore.
                 nullable: true
                 properties:
                   parallelFilesDownload:
-                    description: ParallelFilesDownload is the concurrency number
-                      setting for restore.
+                    description: ParallelFilesDownload is the concurrency number setting
+                      for restore.
                     type: integer
                   writeSparseFiles:
-                    description: WriteSparseFiles is a flag to indicate whether
-                      write files sparsely or not.
+                    description: WriteSparseFiles is a flag to indicate whether write
+                      files sparsely or not.
                     nullable: true
                     type: boolean
                 type: object
@@ -478,8 +476,8 @@ spec:
                   to fail.
                 type: string
               hookStatus:
-                description: HookStatus contains information about the status of
-                  the hooks.
+                description: HookStatus contains information about the status of the
+                  hooks.
                 nullable: true
                 properties:
                   hooksAttempted:
@@ -489,8 +487,8 @@ spec:
                       and the number of hooks that executed successfully.
                     type: integer
                   hooksFailed:
-                    description: HooksFailed is the total number of hooks which
-                      ended with an error
+                    description: HooksFailed is the total number of hooks which ended
+                      with an error
                     type: integer
                 type: object
               phase:
@@ -515,8 +513,8 @@ spec:
                 nullable: true
                 properties:
                   itemsRestored:
-                    description: ItemsRestored is the number of items that have
-                      actually been restored so far
+                    description: ItemsRestored is the number of items that have actually
+                      been restored so far
                     type: integer
                   totalItems:
                     description: |-

--- a/charts/velero/crds/schedules.yaml
+++ b/charts/velero/crds/schedules.yaml
@@ -63,8 +63,7 @@ spec:
             description: ScheduleSpec defines the specification for a Velero schedule
             properties:
               paused:
-                description: Paused specifies whether the schedule is paused or
-                  not
+                description: Paused specifies whether the schedule is paused or not
                 type: boolean
               schedule:
                 description: |-
@@ -145,12 +144,12 @@ spec:
                     nullable: true
                     type: array
                   hooks:
-                    description: Hooks represent custom behaviors that should be
-                      executed at different phases of the backup.
+                    description: Hooks represent custom behaviors that should be executed
+                      at different phases of the backup.
                     properties:
                       resources:
-                        description: Resources are hooks that should be executed
-                          when backing up individual instances of a resource.
+                        description: Resources are hooks that should be executed when
+                          backing up individual instances of a resource.
                         items:
                           description: |-
                             BackupResourceHookSpec defines one or more BackupResourceHooks that should be executed based on
@@ -187,14 +186,13 @@ spec:
                               nullable: true
                               type: array
                             labelSelector:
-                              description: LabelSelector, if specified, filters
-                                the resources to which this hook spec applies.
+                              description: LabelSelector, if specified, filters the
+                                resources to which this hook spec applies.
                               nullable: true
                               properties:
                                 matchExpressions:
                                   description: matchExpressions is a list of label
-                                    selector requirements. The requirements are
-                                    ANDed.
+                                    selector requirements. The requirements are ANDed.
                                   items:
                                     description: |-
                                       A label selector requirement is a selector that contains values, a key, and an operator that
@@ -250,8 +248,8 @@ spec:
                                     description: Exec defines an exec hook.
                                     properties:
                                       command:
-                                        description: Command is the command and
-                                          arguments to execute.
+                                        description: Command is the command and arguments
+                                          to execute.
                                         items:
                                           type: string
                                         minItems: 1
@@ -293,8 +291,8 @@ spec:
                                     description: Exec defines an exec hook.
                                     properties:
                                       command:
-                                        description: Command is the command and
-                                          arguments to execute.
+                                        description: Command is the command and arguments
+                                          to execute.
                                         items:
                                           type: string
                                         minItems: 1
@@ -535,8 +533,8 @@ spec:
                     nullable: true
                     type: boolean
                   storageLocation:
-                    description: StorageLocation is a string containing the name
-                      of a BackupStorageLocation where the backup should be stored.
+                    description: StorageLocation is a string containing the name of
+                      a BackupStorageLocation where the backup should be stored.
                     type: string
                   ttl:
                     description: |-
@@ -544,18 +542,18 @@ spec:
                       the Backup should be retained for.
                     type: string
                   uploaderConfig:
-                    description: UploaderConfig specifies the configuration for
-                      the uploader.
+                    description: UploaderConfig specifies the configuration for the
+                      uploader.
                     nullable: true
                     properties:
                       parallelFilesUpload:
-                        description: ParallelFilesUpload is the number of files
-                          parallel uploads to perform when using the uploader.
+                        description: ParallelFilesUpload is the number of files parallel
+                          uploads to perform when using the uploader.
                         type: integer
                     type: object
                   volumeGroupSnapshotLabelKey:
-                    description: VolumeGroupSnapshotLabelKey specifies the label
-                      key to group PVCs under a VGS.
+                    description: VolumeGroupSnapshotLabelKey specifies the label key
+                      to group PVCs under a VGS.
                     type: string
                   volumeSnapshotLocations:
                     description: VolumeSnapshotLocations is a list containing names

--- a/charts/velero/crds/serverstatusrequests.yaml
+++ b/charts/velero/crds/serverstatusrequests.yaml
@@ -55,8 +55,8 @@ spec:
                 - Processed
                 type: string
               plugins:
-                description: Plugins list information about the plugins running
-                  on the Velero server
+                description: Plugins list information about the plugins running on
+                  the Velero server
                 items:
                   description: PluginInfo contains attributes of a Velero plugin
                   properties:

--- a/charts/velero/crds/volumesnapshotlocations.yaml
+++ b/charts/velero/crds/volumesnapshotlocations.yaml
@@ -55,8 +55,8 @@ spec:
                   to be used with this location
                 properties:
                   key:
-                    description: The key of the secret to select from.  Must be
-                      a valid secret key.
+                    description: The key of the secret to select from.  Must be a
+                      valid secret key.
                     type: string
                   name:
                     default: ""
@@ -85,8 +85,8 @@ spec:
               of a Velero VolumeSnapshotLocation.
             properties:
               phase:
-                description: VolumeSnapshotLocationPhase is the lifecycle phase
-                  of a Velero VolumeSnapshotLocation.
+                description: VolumeSnapshotLocationPhase is the lifecycle phase of
+                  a Velero VolumeSnapshotLocation.
                 enum:
                 - Available
                 - Unavailable

--- a/charts/velero/templates/_helpers.tpl
+++ b/charts/velero/templates/_helpers.tpl
@@ -99,16 +99,11 @@ Create the node-Agent runtime class name.
 
 {{/*
 Kubernetes version
-Built-in object .Capabilities.KubeVersion.Minor can provide non-number output
-For examples:
-- on GKE it returns "18+" instead of "18"
-- on EKS it returns "20+" instead of "20"
 */}}
 {{- define "chart.KubernetesVersion" -}}
-{{- $minorVersion := .Capabilities.KubeVersion.Minor | regexFind "[0-9]+" -}}
-{{- printf "%s.%s" .Capabilities.KubeVersion.Major $minorVersion -}}
+{{- $version := .Capabilities.KubeVersion.Version | regexFind "v[0-9]+\\.[0-9]+\\.[0-9]+" -}}
+{{- printf "%s" $version -}}
 {{- end -}}
-
 
 {{/*
 Calculate the checksum of the credentials secret.

--- a/charts/velero/templates/cleanup-crds.yaml
+++ b/charts/velero/templates/cleanup-crds.yaml
@@ -3,6 +3,8 @@
 # Using this on production systems, especially those that have multiple releases of Velero, will be destructive.
 {{/* 'securityContext' got renamed to 'podSecurityContext', merge both dicts into one for backward compatibility */}}
 {{- $podSecurityContext := merge (.Values.podSecurityContext | default dict) (.Values.securityContext | default dict) -}}
+{{/* Define the list of resources to clean up */}}
+{{- $cleanupResources := list "restore" "backup" "backupstoragelocation" "volumesnapshotlocation" "podvolumerestore" -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -37,6 +39,32 @@ spec:
       {{- end }}
     {{- end }}
       serviceAccountName: {{ include "velero.serverServiceAccount" . }}
+      initContainers:
+        {{- range $cleanupResources }}
+        - name: delete-{{ . }}
+          {{- if $.Values.kubectl.image.digest }}
+          image: "{{ $.Values.kubectl.image.repository }}@{{ $.Values.kubectl.image.digest }}"
+          {{- else if $.Values.kubectl.image.tag }}
+          image: "{{ $.Values.kubectl.image.repository }}:{{ $.Values.kubectl.image.tag }}"
+          {{- else }}
+          image: "{{ $.Values.kubectl.image.repository }}:{{ template "chart.KubernetesVersion" $ }}"
+          {{- end }}
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
+          command:
+            - /bin/kubectl
+          args:
+            - delete
+            - {{ . }}
+            - --all
+          {{- with $.Values.kubectl.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.kubectl.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
       containers:
         - name: kubectl
           {{- if .Values.kubectl.image.digest }}
@@ -48,15 +76,12 @@ spec:
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
-            - /bin/sh
-            - -c
-            - >
-              kubectl delete restore --all;
-              kubectl delete backup --all;
-              kubectl delete backupstoragelocation --all;
-              kubectl delete volumesnapshotlocation --all;
-              kubectl delete podvolumerestore --all;
-              kubectl delete crd -l component=velero;
+            - /bin/kubectl
+          args:
+            - delete
+            - crd
+            - -l
+            - component=velero
           {{- with .Values.kubectl.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/charts/velero/templates/label-namespace/labelnamespace.yaml
+++ b/charts/velero/templates/label-namespace/labelnamespace.yaml
@@ -28,11 +28,13 @@ spec:
         image: "{{ .Values.kubectl.image.repository }}:{{ template "chart.KubernetesVersion" . }}"
         {{- end }}
         command:
-        - /bin/sh
-        - -c
-        - |
+          - /bin/kubectl
+        args:
+          - label
+          - namespace
+          - {{ .Release.Namespace }}
           {{- range $key, $value := .Values.namespace.labels }}
-          kubectl label namespace {{ $.Release.Namespace }} {{ $key }}={{ $value }}
+          - {{ $key }}={{ $value }}
           {{- end }}
         {{- if .Values.kubectl.extraVolumeMounts }}
         volumeMounts:

--- a/charts/velero/templates/node-agent-daemonset.yaml
+++ b/charts/velero/templates/node-agent-daemonset.yaml
@@ -134,12 +134,14 @@ spec:
             - name: cloud-credentials
               mountPath: /credentials
             {{- end }}
+            {{- if not (.Values.nodeAgent.disableHostPath) }}
             - name: host-pods
               mountPath: /host_pods
               mountPropagation: HostToContainer
             - name: host-plugins
               mountPath: /host_plugins
               mountPropagation: HostToContainer
+            {{- end }}
             {{- if .Values.nodeAgent.useScratchEmptyDir }}
             - name: scratch
               mountPath: /scratch

--- a/charts/velero/templates/node-agent-daemonset.yaml
+++ b/charts/velero/templates/node-agent-daemonset.yaml
@@ -78,12 +78,14 @@ spec:
           secret:
             secretName: {{ include "velero.secretName" . }}
         {{- end }}
+        {{- if not (.Values.nodeAgent.disableHostPath) }}
         - name: host-pods
           hostPath:
             path: {{ .Values.nodeAgent.podVolumePath }}
         - name: host-plugins
           hostPath:
             path: {{ .Values.nodeAgent.pluginVolumePath | default "/var/lib/kubelet/plugins" }}
+        {{- end }}
         {{- if .Values.nodeAgent.useScratchEmptyDir }}
         - name: scratch
           emptyDir: {}

--- a/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
@@ -41,32 +41,6 @@ spec:
       serviceAccountName: {{ include "velero.serverServiceAccount" . }}-upgrade-crds
       automountServiceAccountToken: {{ .Values.upgradeCRDsJob.automountServiceAccountToken }}
       initContainers:
-        - name: kubectl
-          {{- if .Values.kubectl.image.digest }}
-          image: "{{ .Values.kubectl.image.repository }}@{{ .Values.kubectl.image.digest }}"
-          {{- else if .Values.kubectl.image.tag }}
-          image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
-          {{- else }}
-          image: "{{ .Values.kubectl.image.repository }}:{{ template "chart.KubernetesVersion" . }}"
-          {{- end }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
-            - /bin/sh
-          args:
-            - -c
-            - cp `which sh` /tmp && cp `which kubectl` /tmp
-          {{- with .Values.kubectl.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.kubectl.containerSecurityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          volumeMounts:
-            - mountPath: /tmp
-              name: crds
-      containers:
         - name: velero
           {{- if .Values.image.digest }}
           image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
@@ -78,7 +52,7 @@ spec:
             - {{ .Values.upgradeCRDsJob.shellCmd | default "/tmp/sh" }}
           args:
             - -c
-            - {{ .Values.upgradeCRDsJob.updateCmd | default "/velero install --crds-only --dry-run -o yaml | /tmp/kubectl apply -f -" }}
+            - {{ .Values.upgradeCRDsJob.updateCmd | default "/velero install --crds-only --dry-run -o yaml > /tmp/crds.yaml" }}
           {{- with .Values.upgradeJobResources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -99,6 +73,32 @@ spec:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
+      containers:
+        - name: kubectl
+          {{- if .Values.kubectl.image.digest }}
+          image: "{{ .Values.kubectl.image.repository }}@{{ .Values.kubectl.image.digest }}"
+          {{- else if .Values.kubectl.image.tag }}
+          image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
+          {{- else }}
+          image: "{{ .Values.kubectl.image.repository }}:{{ template "chart.KubernetesVersion" . }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/kubectl
+          args:
+            - -f
+            - /tmp/crds.yaml
+          {{- with .Values.kubectl.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.kubectl.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - mountPath: /tmp
+              name: crds
       volumes:
         - name: crds
           emptyDir: {}

--- a/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
@@ -49,10 +49,15 @@ spec:
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
-            - {{ .Values.upgradeCRDsJob.shellCmd | default "/tmp/sh" }}
+            - /velero
           args:
-            - -c
-            - {{ .Values.upgradeCRDsJob.updateCmd | default "/velero install --crds-only --dry-run -o yaml > /tmp/crds.yaml" }}
+            - install
+            - --crds-only
+            - --dry-run
+            - -o
+            - yaml
+            - >
+            - /tmp/crds.yaml
           {{- with .Values.upgradeJobResources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
@@ -52,8 +52,8 @@ spec:
             - /velero
           args:
             - install
-            - --upgrade
             - --crds-only
+            - --apply
           {{- with .Values.upgradeJobResources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
@@ -40,7 +40,7 @@ spec:
     {{- end }}
       serviceAccountName: {{ include "velero.serverServiceAccount" . }}-upgrade-crds
       automountServiceAccountToken: {{ .Values.upgradeCRDsJob.automountServiceAccountToken }}
-      initContainers:
+      containers:
         - name: velero
           {{- if .Values.image.digest }}
           image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
@@ -52,12 +52,8 @@ spec:
             - /velero
           args:
             - install
+            - --upgrade
             - --crds-only
-            - --dry-run
-            - -o
-            - yaml
-            - >
-            - /tmp/crds.yaml
           {{- with .Values.upgradeJobResources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -66,10 +62,8 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          volumeMounts:
-            - mountPath: /tmp
-              name: crds
           {{- if (.Values.upgradeCRDsJob).extraVolumeMounts }}
+          volumeMounts:
           {{- toYaml .Values.upgradeCRDsJob.extraVolumeMounts | nindent 12 }}
           {{- end }}
           {{- if (.Values.upgradeCRDsJob).extraEnvVars }}
@@ -78,38 +72,10 @@ spec:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
-      containers:
-        - name: kubectl
-          {{- if .Values.kubectl.image.digest }}
-          image: "{{ .Values.kubectl.image.repository }}@{{ .Values.kubectl.image.digest }}"
-          {{- else if .Values.kubectl.image.tag }}
-          image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
-          {{- else }}
-          image: "{{ .Values.kubectl.image.repository }}:{{ template "chart.KubernetesVersion" . }}"
-          {{- end }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
-            - /bin/kubectl
-          args:
-            - -f
-            - /tmp/crds.yaml
-          {{- with .Values.kubectl.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.kubectl.containerSecurityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          volumeMounts:
-            - mountPath: /tmp
-              name: crds
+      {{- if (.Values.upgradeCRDsJob).extraVolumes }}
       volumes:
-        - name: crds
-          emptyDir: {}
-        {{- if (.Values.upgradeCRDsJob).extraVolumes }}
         {{- toYaml .Values.upgradeCRDsJob.extraVolumes | nindent 8 }}
-        {{- end }}
+      {{- end }}
       restartPolicy: OnFailure
       {{- with $podSecurityContext }}
       securityContext:

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -27,7 +27,7 @@ namespace:
 # enabling node-agent). Required.
 image:
   repository: velero/velero
-  tag: v1.17.1
+  tag: v1.17.2
   # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
   # If used, it will take precedence over the image.tag.
   # digest:

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -18,7 +18,6 @@ namespace:
 ## End of namespace-related settings.
 ##
 
-
 ##
 ## Configuration settings that directly affect the Velero deployment YAML.
 ##
@@ -27,7 +26,7 @@ namespace:
 # enabling node-agent). Required.
 image:
   repository: velero/velero
-  tag: v1.17.2
+  tag: v1.17.1
   # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
   # If used, it will take precedence over the image.tag.
   # digest:
@@ -36,8 +35,8 @@ image:
   imagePullSecrets: []
   # - registrySecretName
 
-nameOverride: ""
-fullnameOverride: ""
+nameOverride: ''
+fullnameOverride: ''
 
 # Annotations to add to the Velero deployment's. Optional.
 #
@@ -152,10 +151,10 @@ containerSecurityContext: {}
 lifecycle: {}
 
 # Pod priority class name to use for the Velero deployment. Optional.
-priorityClassName: ""
+priorityClassName: ''
 
 # Pod runtime class name to use for the Velero deployment. Optional.
-runtimeClassName: ""
+runtimeClassName: ''
 
 # The number of seconds to allow for graceful termination of the pod. Optional.
 terminationGracePeriodSeconds: 3600
@@ -243,19 +242,19 @@ metrics:
 
     # External/Internal traffic policy setting (Cluster, Local)
     # https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-policies
-    externalTrafficPolicy: ""
-    internalTrafficPolicy: ""
+    externalTrafficPolicy: ''
+    internalTrafficPolicy: ''
 
     # the IP family policy for the metrics Service to be able to configure dual-stack; see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services).
-    ipFamilyPolicy: ""
+    ipFamilyPolicy: ''
     # a list of IP families for the metrics Service that should be supported, in the order in which they should be applied to ClusterIP. Can be "IPv4" and/or "IPv6".
     ipFamilies: []
 
   # Pod annotations for Prometheus
   podAnnotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "8085"
-    prometheus.io/path: "/metrics"
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '8085'
+    prometheus.io/path: '/metrics'
 
   serviceMonitor:
     autodetect: true
@@ -371,7 +370,6 @@ cleanUpCRDs: false
 ## End of deployment-related settings.
 ##
 
-
 ##
 ## Parameters for the `default` BackupStorageLocation and VolumeSnapshotLocation,
 ## and additional server settings.
@@ -382,76 +380,76 @@ configuration:
   backupStorageLocation:
     # name is the name of the backup storage location where backups should be stored. If a name is not provided,
     # a backup storage location will be created with the name "default". Optional.
-  - name:
-    # provider is the name for the backup storage location provider.
-    provider: ""
-    # bucket is the name of the bucket to store backups in. Required.
-    bucket: ""
-    # caCert defines a base64 encoded CA bundle to use when verifying TLS connections to the provider. Optional.
-    caCert:
-    # prefix is the directory under which all Velero data should be stored within the bucket. Optional.
-    prefix:
-    # default indicates this location is the default backup storage location. Optional.
-    default: false
-    # validationFrequency defines how frequently Velero should validate the object storage. Optional.
-    validationFrequency:
-    # accessMode determines if velero can write to this backup storage location. Optional.
-    # default to ReadWrite, ReadOnly is used during migrations and restores.
-    accessMode: ReadWrite
-    credential:
-      # name of the secret used by this backupStorageLocation.
-      name:
-      # name of key that contains the secret data to be used.
-      key:
-    # Additional provider-specific configuration. See link above
-    # for details of required/optional fields for your provider.
-    config: {}
-    #  region:
-    #  s3ForcePathStyle:
-    #  s3Url:
-    #  kmsKeyId:
-    #  resourceGroup:
-    #  The ID of the subscription containing the storage account, if different from the cluster’s subscription. (Azure only)
-    #  subscriptionId:
-    #  storageAccount:
-    #  publicUrl:
-    #  Name of the GCP service account to use for this backup storage location. Specify the
-    #  service account here if you want to use workload identity instead of providing the key file.(GCP only)
-    #  serviceAccount:
-    #  Option to skip certificate validation or not if insecureSkipTLSVerify is set to be true, the client side should set the
-    #  flag. For Velero client Command like velero backup describe, velero backup logs needs to add the flag --insecure-skip-tls-verify
-    #  insecureSkipTLSVerify:
+    - name:
+      # provider is the name for the backup storage location provider.
+      provider: ''
+      # bucket is the name of the bucket to store backups in. Required.
+      bucket: ''
+      # caCert defines a base64 encoded CA bundle to use when verifying TLS connections to the provider. Optional.
+      caCert:
+      # prefix is the directory under which all Velero data should be stored within the bucket. Optional.
+      prefix:
+      # default indicates this location is the default backup storage location. Optional.
+      default: false
+      # validationFrequency defines how frequently Velero should validate the object storage. Optional.
+      validationFrequency:
+      # accessMode determines if velero can write to this backup storage location. Optional.
+      # default to ReadWrite, ReadOnly is used during migrations and restores.
+      accessMode: ReadWrite
+      credential:
+        # name of the secret used by this backupStorageLocation.
+        name:
+        # name of key that contains the secret data to be used.
+        key:
+      # Additional provider-specific configuration. See link above
+      # for details of required/optional fields for your provider.
+      config: {}
+      #  region:
+      #  s3ForcePathStyle:
+      #  s3Url:
+      #  kmsKeyId:
+      #  resourceGroup:
+      #  The ID of the subscription containing the storage account, if different from the cluster’s subscription. (Azure only)
+      #  subscriptionId:
+      #  storageAccount:
+      #  publicUrl:
+      #  Name of the GCP service account to use for this backup storage location. Specify the
+      #  service account here if you want to use workload identity instead of providing the key file.(GCP only)
+      #  serviceAccount:
+      #  Option to skip certificate validation or not if insecureSkipTLSVerify is set to be true, the client side should set the
+      #  flag. For Velero client Command like velero backup describe, velero backup logs needs to add the flag --insecure-skip-tls-verify
+      #  insecureSkipTLSVerify:
 
-    # annotations allows adding arbitrary annotations to this BackupStorageLocation resource. Optional.
-    annotations: {}
+      # annotations allows adding arbitrary annotations to this BackupStorageLocation resource. Optional.
+      annotations: {}
 
   # Parameters for the VolumeSnapshotLocation(s). Configure multiple by adding other element(s) to the volumeSnapshotLocation slice.
   # See https://velero.io/docs/v1.6/api-types/volumesnapshotlocation/
   volumeSnapshotLocation:
     # name is the name of the volume snapshot location where snapshots are being taken. If a name is not provided,
     # a volume snapshot location will be created with the name "default". Optional.
-  - name:
-    # provider is the name for the volume snapshot provider.
-    provider: ""
-    credential:
-      # name of the secret used by this volumeSnapshotLocation.
-      name:
-      # name of key that contains the secret data to be used.
-      key:
-    # Additional provider-specific configuration. See link above
-    # for details of required/optional fields for your provider.
-    config: {}
-  #    region:
-  #    apiTimeout:
-  #    resourceGroup:
-  #    The ID of the subscription where volume snapshots should be stored, if different from the cluster’s subscription. If specified, also requires `configuration.volumeSnapshotLocation.config.resourceGroup`to be set. (Azure only)
-  #    subscriptionId:
-  #    incremental:
-  #    snapshotLocation:
-  #    project:
+    - name:
+      # provider is the name for the volume snapshot provider.
+      provider: ''
+      credential:
+        # name of the secret used by this volumeSnapshotLocation.
+        name:
+        # name of key that contains the secret data to be used.
+        key:
+      # Additional provider-specific configuration. See link above
+      # for details of required/optional fields for your provider.
+      config: {}
+      #    region:
+      #    apiTimeout:
+      #    resourceGroup:
+      #    The ID of the subscription where volume snapshots should be stored, if different from the cluster’s subscription. If specified, also requires `configuration.volumeSnapshotLocation.config.resourceGroup`to be set. (Azure only)
+      #    subscriptionId:
+      #    incremental:
+      #    snapshotLocation:
+      #    project:
 
-    # annotations allows adding arbitrary annotations to this VolumeSnapshotLocation resource. Optional.
-    annotations: {}
+      # annotations allows adding arbitrary annotations to this VolumeSnapshotLocation resource. Optional.
+      annotations: {}
 
   # These are server-level settings passed as CLI flags to the `velero server` command. Velero
   # uses default values if they're not passed in, so they only need to be explicitly specified
@@ -519,7 +517,7 @@ configuration:
     # See: https://velero.io/docs/main/repository-maintenance/
     repositoryConfigData:
       # Name of the ConfigMap to create. If not provided, will use "velero-repo-maintenance"
-      name: "velero-repo-maintenance"
+      name: 'velero-repo-maintenance'
       # Global configuration applied to all repositories
       # This configuration is used when no specific repository configuration is found
       # global:
@@ -584,7 +582,6 @@ configuration:
 ## End of backup/snapshot location settings.
 ##
 
-
 ##
 ## Settings for additional Velero resources.
 ##
@@ -640,7 +637,7 @@ credentials:
   # Name of a pre-existing secret (if any) in the Velero namespace
   # that will be used to load environment variables into velero and node-agent.
   # Secret should be in format - https://kubernetes.io/docs/concepts/configuration/secret/#use-case-as-container-environment-variables
-  extraSecretRef: ""
+  extraSecretRef: ''
 
 # Whether to create backupstoragelocation crd, if false => do not create a default backup location
 backupsEnabled: true
@@ -654,9 +651,9 @@ nodeAgent:
   podVolumePath: /var/lib/kubelet/pods
   pluginVolumePath: /var/lib/kubelet/plugins
   # Pod priority class name to use for the node-agent daemonset. Optional.
-  priorityClassName: ""
+  priorityClassName: ''
   # Pod runtime class name to use for the node-agent daemonset. Optional.
-  runtimeClassName: ""
+  runtimeClassName: ''
   # Resource requests/limits to specify for the node-agent daemonset deployment. Optional.
   # https://velero.io/docs/v1.6/customize-installation/#customize-resource-requests-and-limits
   resources: {}
@@ -780,7 +777,7 @@ schedules: {}
 # Velero ConfigMaps.
 # Eg:
 # configMaps:
-    # See: https://velero.io/docs/v1.11/file-system-backup/
+# See: https://velero.io/docs/v1.11/file-system-backup/
 #   fs-restore-action-config:
 #     labels:
 #       velero.io/plugin-config: ""
@@ -801,7 +798,6 @@ schedules: {}
 #         runAsUser: 1001
 #         runAsGroup: 999
 configMaps: {}
-
 ##
 ## End of additional Velero resource settings.
 ##

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -26,7 +26,7 @@ namespace:
 # enabling node-agent). Required.
 image:
   repository: velero/velero
-  tag: v1.17.1
+  tag: v1.18.0-rc.1
   # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
   # If used, it will take precedence over the image.tag.
   # digest:

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -336,7 +336,7 @@ metrics:
 kubectl:
   image:
     repository: registry.k8s.io/kubectl
-    # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
+    # Digest value example: sha256:54e66c42a1d3a11a1ed4f866ce9fff7e1e48f32a1cb147e3b98a05168a429917.
     # If used, it will take precedence over the kubectl.image.tag.
     # digest:
     # kubectl image tag. If used, it will take precedence over the cluster Kubernetes version.

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -338,12 +338,12 @@ metrics:
 
 kubectl:
   image:
-    repository: docker.io/bitnami/kubectl
+    repository: registry.k8s.io/kubectl
     # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
     # If used, it will take precedence over the kubectl.image.tag.
     # digest:
     # kubectl image tag. If used, it will take precedence over the cluster Kubernetes version.
-    # tag: 1.16.15
+    # tag: v1.32.8
   # Container Level Security Context for the 'kubectl' container of the crd jobs. Optional.
   # See: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   containerSecurityContext: {}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -648,6 +648,8 @@ snapshotsEnabled: true
 deployNodeAgent: false
 
 nodeAgent:
+  # Disables Host Path volumes for node-agent.
+  disableHostPath: false
   podVolumePath: /var/lib/kubelet/pods
   pluginVolumePath: /var/lib/kubelet/plugins
   # Pod priority class name to use for the node-agent daemonset. Optional.

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -339,12 +339,12 @@ metrics:
 
 kubectl:
   image:
-    repository: registry.k8s.io/kubectl
-    # Digest value example: sha256:54e66c42a1d3a11a1ed4f866ce9fff7e1e48f32a1cb147e3b98a05168a429917.
+    repository: docker.io/bitnamilegacy/kubectl
+    # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
     # If used, it will take precedence over the kubectl.image.tag.
     # digest:
     # kubectl image tag. If used, it will take precedence over the cluster Kubernetes version.
-    # tag: v1.32.8
+    # tag: v1.34.4
   # Container Level Security Context for the 'kubectl' container of the crd jobs. Optional.
   # See: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   containerSecurityContext: {}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -118,9 +118,6 @@ upgradeCRDsJob:
 
   # Configure if API credential for Service Account is automounted.
   automountServiceAccountToken: true
-  # Configure the shell cmd in case you are using custom image
-  # shellCmd: /tmp/sh
-  # updateCmd: /velero install --crds-only --dry-run -o yaml | /tmp/kubectl apply -f -
 
 # Configure the dnsPolicy of the Velero deployment
 # See: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -18,6 +18,7 @@ namespace:
 ## End of namespace-related settings.
 ##
 
+
 ##
 ## Configuration settings that directly affect the Velero deployment YAML.
 ##
@@ -35,8 +36,8 @@ image:
   imagePullSecrets: []
   # - registrySecretName
 
-nameOverride: ''
-fullnameOverride: ''
+nameOverride: ""
+fullnameOverride: ""
 
 # Annotations to add to the Velero deployment's. Optional.
 #
@@ -117,6 +118,9 @@ upgradeCRDsJob:
 
   # Configure if API credential for Service Account is automounted.
   automountServiceAccountToken: true
+  # Configure the shell cmd in case you are using custom image
+  # shellCmd: /tmp/sh
+  # updateCmd: /velero install --crds-only --dry-run -o yaml | /tmp/kubectl apply -f -
 
 # Configure the dnsPolicy of the Velero deployment
 # See: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
@@ -151,10 +155,10 @@ containerSecurityContext: {}
 lifecycle: {}
 
 # Pod priority class name to use for the Velero deployment. Optional.
-priorityClassName: ''
+priorityClassName: ""
 
 # Pod runtime class name to use for the Velero deployment. Optional.
-runtimeClassName: ''
+runtimeClassName: ""
 
 # The number of seconds to allow for graceful termination of the pod. Optional.
 terminationGracePeriodSeconds: 3600
@@ -242,19 +246,19 @@ metrics:
 
     # External/Internal traffic policy setting (Cluster, Local)
     # https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-policies
-    externalTrafficPolicy: ''
-    internalTrafficPolicy: ''
+    externalTrafficPolicy: ""
+    internalTrafficPolicy: ""
 
     # the IP family policy for the metrics Service to be able to configure dual-stack; see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services).
-    ipFamilyPolicy: ''
+    ipFamilyPolicy: ""
     # a list of IP families for the metrics Service that should be supported, in the order in which they should be applied to ClusterIP. Can be "IPv4" and/or "IPv6".
     ipFamilies: []
 
   # Pod annotations for Prometheus
   podAnnotations:
-    prometheus.io/scrape: 'true'
-    prometheus.io/port: '8085'
-    prometheus.io/path: '/metrics'
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8085"
+    prometheus.io/path: "/metrics"
 
   serviceMonitor:
     autodetect: true
@@ -339,12 +343,12 @@ metrics:
 
 kubectl:
   image:
-    repository: docker.io/bitnamilegacy/kubectl
-    # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
+    repository: registry.k8s.io/kubectl
+    # Digest value example: sha256:c7bf8cf6e79f474fda2623a7b98572a1b909c4d912b05062b444ffe79883fdbe.
     # If used, it will take precedence over the kubectl.image.tag.
     # digest:
     # kubectl image tag. If used, it will take precedence over the cluster Kubernetes version.
-    # tag: v1.34.4
+    # tag: v1.34.5
   # Container Level Security Context for the 'kubectl' container of the crd jobs. Optional.
   # See: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   containerSecurityContext: {}
@@ -370,6 +374,7 @@ cleanUpCRDs: false
 ## End of deployment-related settings.
 ##
 
+
 ##
 ## Parameters for the `default` BackupStorageLocation and VolumeSnapshotLocation,
 ## and additional server settings.
@@ -380,76 +385,76 @@ configuration:
   backupStorageLocation:
     # name is the name of the backup storage location where backups should be stored. If a name is not provided,
     # a backup storage location will be created with the name "default". Optional.
-    - name:
-      # provider is the name for the backup storage location provider.
-      provider: ''
-      # bucket is the name of the bucket to store backups in. Required.
-      bucket: ''
-      # caCert defines a base64 encoded CA bundle to use when verifying TLS connections to the provider. Optional.
-      caCert:
-      # prefix is the directory under which all Velero data should be stored within the bucket. Optional.
-      prefix:
-      # default indicates this location is the default backup storage location. Optional.
-      default: false
-      # validationFrequency defines how frequently Velero should validate the object storage. Optional.
-      validationFrequency:
-      # accessMode determines if velero can write to this backup storage location. Optional.
-      # default to ReadWrite, ReadOnly is used during migrations and restores.
-      accessMode: ReadWrite
-      credential:
-        # name of the secret used by this backupStorageLocation.
-        name:
-        # name of key that contains the secret data to be used.
-        key:
-      # Additional provider-specific configuration. See link above
-      # for details of required/optional fields for your provider.
-      config: {}
-      #  region:
-      #  s3ForcePathStyle:
-      #  s3Url:
-      #  kmsKeyId:
-      #  resourceGroup:
-      #  The ID of the subscription containing the storage account, if different from the cluster’s subscription. (Azure only)
-      #  subscriptionId:
-      #  storageAccount:
-      #  publicUrl:
-      #  Name of the GCP service account to use for this backup storage location. Specify the
-      #  service account here if you want to use workload identity instead of providing the key file.(GCP only)
-      #  serviceAccount:
-      #  Option to skip certificate validation or not if insecureSkipTLSVerify is set to be true, the client side should set the
-      #  flag. For Velero client Command like velero backup describe, velero backup logs needs to add the flag --insecure-skip-tls-verify
-      #  insecureSkipTLSVerify:
+  - name:
+    # provider is the name for the backup storage location provider.
+    provider: ""
+    # bucket is the name of the bucket to store backups in. Required.
+    bucket: ""
+    # caCert defines a base64 encoded CA bundle to use when verifying TLS connections to the provider. Optional.
+    caCert:
+    # prefix is the directory under which all Velero data should be stored within the bucket. Optional.
+    prefix:
+    # default indicates this location is the default backup storage location. Optional.
+    default: false
+    # validationFrequency defines how frequently Velero should validate the object storage. Optional.
+    validationFrequency:
+    # accessMode determines if velero can write to this backup storage location. Optional.
+    # default to ReadWrite, ReadOnly is used during migrations and restores.
+    accessMode: ReadWrite
+    credential:
+      # name of the secret used by this backupStorageLocation.
+      name:
+      # name of key that contains the secret data to be used.
+      key:
+    # Additional provider-specific configuration. See link above
+    # for details of required/optional fields for your provider.
+    config: {}
+    #  region:
+    #  s3ForcePathStyle:
+    #  s3Url:
+    #  kmsKeyId:
+    #  resourceGroup:
+    #  The ID of the subscription containing the storage account, if different from the cluster’s subscription. (Azure only)
+    #  subscriptionId:
+    #  storageAccount:
+    #  publicUrl:
+    #  Name of the GCP service account to use for this backup storage location. Specify the
+    #  service account here if you want to use workload identity instead of providing the key file.(GCP only)
+    #  serviceAccount:
+    #  Option to skip certificate validation or not if insecureSkipTLSVerify is set to be true, the client side should set the
+    #  flag. For Velero client Command like velero backup describe, velero backup logs needs to add the flag --insecure-skip-tls-verify
+    #  insecureSkipTLSVerify:
 
-      # annotations allows adding arbitrary annotations to this BackupStorageLocation resource. Optional.
-      annotations: {}
+    # annotations allows adding arbitrary annotations to this BackupStorageLocation resource. Optional.
+    annotations: {}
 
   # Parameters for the VolumeSnapshotLocation(s). Configure multiple by adding other element(s) to the volumeSnapshotLocation slice.
   # See https://velero.io/docs/v1.6/api-types/volumesnapshotlocation/
   volumeSnapshotLocation:
     # name is the name of the volume snapshot location where snapshots are being taken. If a name is not provided,
     # a volume snapshot location will be created with the name "default". Optional.
-    - name:
-      # provider is the name for the volume snapshot provider.
-      provider: ''
-      credential:
-        # name of the secret used by this volumeSnapshotLocation.
-        name:
-        # name of key that contains the secret data to be used.
-        key:
-      # Additional provider-specific configuration. See link above
-      # for details of required/optional fields for your provider.
-      config: {}
-      #    region:
-      #    apiTimeout:
-      #    resourceGroup:
-      #    The ID of the subscription where volume snapshots should be stored, if different from the cluster’s subscription. If specified, also requires `configuration.volumeSnapshotLocation.config.resourceGroup`to be set. (Azure only)
-      #    subscriptionId:
-      #    incremental:
-      #    snapshotLocation:
-      #    project:
+  - name:
+    # provider is the name for the volume snapshot provider.
+    provider: ""
+    credential:
+      # name of the secret used by this volumeSnapshotLocation.
+      name:
+      # name of key that contains the secret data to be used.
+      key:
+    # Additional provider-specific configuration. See link above
+    # for details of required/optional fields for your provider.
+    config: {}
+  #    region:
+  #    apiTimeout:
+  #    resourceGroup:
+  #    The ID of the subscription where volume snapshots should be stored, if different from the cluster’s subscription. If specified, also requires `configuration.volumeSnapshotLocation.config.resourceGroup`to be set. (Azure only)
+  #    subscriptionId:
+  #    incremental:
+  #    snapshotLocation:
+  #    project:
 
-      # annotations allows adding arbitrary annotations to this VolumeSnapshotLocation resource. Optional.
-      annotations: {}
+    # annotations allows adding arbitrary annotations to this VolumeSnapshotLocation resource. Optional.
+    annotations: {}
 
   # These are server-level settings passed as CLI flags to the `velero server` command. Velero
   # uses default values if they're not passed in, so they only need to be explicitly specified
@@ -517,7 +522,7 @@ configuration:
     # See: https://velero.io/docs/main/repository-maintenance/
     repositoryConfigData:
       # Name of the ConfigMap to create. If not provided, will use "velero-repo-maintenance"
-      name: 'velero-repo-maintenance'
+      name: "velero-repo-maintenance"
       # Global configuration applied to all repositories
       # This configuration is used when no specific repository configuration is found
       # global:
@@ -582,6 +587,7 @@ configuration:
 ## End of backup/snapshot location settings.
 ##
 
+
 ##
 ## Settings for additional Velero resources.
 ##
@@ -637,7 +643,7 @@ credentials:
   # Name of a pre-existing secret (if any) in the Velero namespace
   # that will be used to load environment variables into velero and node-agent.
   # Secret should be in format - https://kubernetes.io/docs/concepts/configuration/secret/#use-case-as-container-environment-variables
-  extraSecretRef: ''
+  extraSecretRef: ""
 
 # Whether to create backupstoragelocation crd, if false => do not create a default backup location
 backupsEnabled: true
@@ -653,9 +659,9 @@ nodeAgent:
   podVolumePath: /var/lib/kubelet/pods
   pluginVolumePath: /var/lib/kubelet/plugins
   # Pod priority class name to use for the node-agent daemonset. Optional.
-  priorityClassName: ''
+  priorityClassName: ""
   # Pod runtime class name to use for the node-agent daemonset. Optional.
-  runtimeClassName: ''
+  runtimeClassName: ""
   # Resource requests/limits to specify for the node-agent daemonset deployment. Optional.
   # https://velero.io/docs/v1.6/customize-installation/#customize-resource-requests-and-limits
   resources: {}
@@ -779,7 +785,7 @@ schedules: {}
 # Velero ConfigMaps.
 # Eg:
 # configMaps:
-# See: https://velero.io/docs/v1.11/file-system-backup/
+    # See: https://velero.io/docs/v1.11/file-system-backup/
 #   fs-restore-action-config:
 #     labels:
 #       velero.io/plugin-config: ""
@@ -800,6 +806,7 @@ schedules: {}
 #         runAsUser: 1001
 #         runAsGroup: 999
 configMaps: {}
+
 ##
 ## End of additional Velero resource settings.
 ##

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -26,7 +26,7 @@ namespace:
 # enabling node-agent). Required.
 image:
   repository: velero/velero
-  tag: v1.18.0-rc.1
+  tag: v1.18.0
   # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
   # If used, it will take precedence over the image.tag.
   # digest:

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -25,7 +25,7 @@ namespace:
 # Details of the container image to use in the Velero deployment & daemonset (if
 # enabling node-agent). Required.
 image:
-  repository: velero/velero
+  repository: docker.io/velero/velero
   tag: v1.18.0
   # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
   # If used, it will take precedence over the image.tag.

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -28,7 +28,7 @@ namespace:
 image:
   repository: docker.io/velero/velero
   tag: v1.18.0
-  # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
+  # Digest value example: sha256:73266e6bd7e2fe3f65fb20677d36c4a8df76d417d9ba76bd9932e0d983a776ec.
   # If used, it will take precedence over the image.tag.
   # digest:
   pullPolicy: IfNotPresent


### PR DESCRIPTION
#### Special notes for your reviewer:

Try to fix https://github.com/vmware-tanzu/helm-charts/issues/698
#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)

For moment, it's just an idea to remove bitnami kubectl and the need for sh :)

What do you think ?