### PR TITLE
[velero] Move to bitnamilegacy

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.16.2
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 10.1.1
+version: 10.1.2
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -338,7 +338,7 @@ metrics:
 
 kubectl:
   image:
-    repository: docker.io/bitnami/kubectl
+    repository: docker.io/bitnamilegacy/kubectl
     # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
     # If used, it will take precedence over the kubectl.image.tag.
     # digest:


### PR DESCRIPTION
#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)

This pull request is a short term solution as bitnami will delete images from actual repository `docker.io/bitnami` and we have to migrate to `docker.io/bitnamilegacy` before September the 29th (see [here](https://community.broadcom.com/tanzu/blogs/beltran-rueda-borrego/2025/08/18/how-to-prepare-for-the-bitnami-changes-coming-soon)).

I have made another [pull request](https://github.com/vmware-tanzu/helm-charts/pull/706) which is better for the future and `kubectl` image updates.

But it depends of this [pull request](https://github.com/vmware-tanzu/velero/pull/9132) and I'm not sure everything will be merged before September the 29th.