### PR TITLE
[velero] correct initContainer value json schema

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.16.2
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 10.1.2
+version: 10.1.3
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/values.schema.json
+++ b/charts/velero/values.schema.json
@@ -105,7 +105,7 @@
             "type": "string"
         },
         "initContainers": {
-            "type": ["array", "null"],
+            "type": ["array", "string", "null"],
             "items": {}
         },
         "podSecurityContext": {


### PR DESCRIPTION
#### Special notes for your reviewer:
[The deployment template](https://github.com/vmware-tanzu/helm-charts/blob/3d2d76e399488a7674ce4ade8b350932b86a9b08/charts/velero/templates/deployment.yaml#L289) supports strings as well as arrays/null, therefore the string type should be included in the values schema.
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
