### PR TITLE
[velero] chore(upgrade-crds) double quote cp command for better shell compatibility

### DIFF
--- a/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
@@ -54,7 +54,8 @@ spec:
             - /bin/sh
           args:
             - -c
-            - cp `which sh` /tmp && cp `which kubectl` /tmp
+            - |
+              "cp `which sh` /tmp && cp `which kubectl` /tmp"
           {{- with .Values.kubectl.resources }}
           resources:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
#### Special notes for your reviewer:

I tried to use another kubectl image, like `alpine/kubectl`. But running 
```shell
/bin/sh -c cp `which sh` /tmp && cp `which kubectl` /tmp
```
not works as well. The command needs to be quoted: 
```shell
/bin/sh -c "cp `which sh` /tmp && cp `which kubectl` /tmp"
```


#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
