### PR TITLE
[velero] fix: also conditionally include volume mounts for nodeagent (#710)

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.17.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 11.3.1
+version: 11.3.2
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/node-agent-daemonset.yaml
+++ b/charts/velero/templates/node-agent-daemonset.yaml
@@ -134,12 +134,14 @@ spec:
             - name: cloud-credentials
               mountPath: /credentials
             {{- end }}
+            {{- if not (.Values.nodeAgent.disableHostPath) }}
             - name: host-pods
               mountPath: /host_pods
               mountPropagation: HostToContainer
             - name: host-plugins
               mountPath: /host_plugins
               mountPropagation: HostToContainer
+            {{- end }}
             {{- if .Values.nodeAgent.useScratchEmptyDir }}
             - name: scratch
               mountPath: /scratch


### PR DESCRIPTION
#### Special notes for your reviewer:
https://github.com/vmware-tanzu/helm-charts/pull/717 was released today, however there is an issue that
the volumeMounts are not rendered conditionally. This will trigger the error:

```
Helm upgrade failed for release <>
      with chart velero@11.3.1: failed to create resource: DaemonSet.apps "node-agent"
      is invalid: [spec.template.spec.containers[0[].volumeMounts[1].name: Not found:
      "host-pods", spec.template.spec.containers[0[].volumeMounts[2].name: Not found:
      "host-plugins"]
```

To reproduce:
 - Install the helm chart with `deployNodeAgent: true` and `nodeAgent.disableHostPath: true`
 
#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
