### PR TITLE
feat: make backoffLimit configurable for Helm jobs

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.17.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 11.4.0
+version: 11.4.1
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.17.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 11.3.2
+version: 11.4.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/cleanup-crds.yaml
+++ b/charts/velero/templates/cleanup-crds.yaml
@@ -3,6 +3,7 @@
 # Using this on production systems, especially those that have multiple releases of Velero, will be destructive.
 {{/* 'securityContext' got renamed to 'podSecurityContext', merge both dicts into one for backward compatibility */}}
 {{- $podSecurityContext := merge (.Values.podSecurityContext | default dict) (.Values.securityContext | default dict) -}}
+{{- $cleanUpCRDsJob := .Values.cleanUpCRDsJob | default dict -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -17,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "velero.chart" . }}
 spec:
-  backoffLimit: 3
+  backoffLimit: {{ default 3 $cleanUpCRDsJob.backoffLimit }}
   template:
     metadata:
       name: velero-cleanup-crds

--- a/charts/velero/templates/label-namespace/labelnamespace.yaml
+++ b/charts/velero/templates/label-namespace/labelnamespace.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.namespace }}
 {{- if gt (len .Values.namespace.labels) 0 }}
+{{- $labelNamespaceJob := .Values.labelNamespaceJob | default dict -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -43,6 +44,6 @@ spec:
       volumes:
       {{- toYaml .Values.kubectl.extraVolumes | nindent 6 }}
       {{- end }}
-  backoffLimit: 3
+  backoffLimit: {{ default 3 $labelNamespaceJob.backoffLimit }}
 {{- end }}
 {{- end }}

--- a/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  backoffLimit: {{ default 3 $upgradeCRDsJob.backoffLimit }}
+  backoffLimit: {{ $upgradeCRDsJob.backoffLimit }}
   template:
     metadata:
       name: velero-upgrade-crds

--- a/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.upgradeCRDs }}
 {{/* 'securityContext' got renamed to 'podSecurityContext', merge both dicts into one for backward compatibility */}}
 {{- $podSecurityContext := merge (.Values.podSecurityContext | default dict) (.Values.securityContext | default dict) -}}
+{{- $upgradeCRDsJob := .Values.upgradeCRDsJob | default dict -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -19,7 +20,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  backoffLimit: 3
+  backoffLimit: {{ default 3 $upgradeCRDsJob.backoffLimit }}
   template:
     metadata:
       name: velero-upgrade-crds

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -14,6 +14,11 @@ namespace:
     # pod-security.kubernetes.io/warn: privileged
     # pod-security.kubernetes.io/warn-version: latest
 
+labelNamespaceJob:
+  # Specifies the number of retries before marking the label namespace job as failed.
+  # See: https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy
+  backoffLimit: 3
+
 ##
 ## End of namespace-related settings.
 ##
@@ -100,6 +105,9 @@ upgradeJobResources: {}
 #     cpu: 100m
 #     memory: 256Mi
 upgradeCRDsJob:
+  # Specifies the number of retries before marking the upgrade CRDs job as failed.
+  # See: https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy
+  backoffLimit: 3
   # Extra volumes for the Upgrade CRDs Job. Optional.
   extraVolumes: []
   # Extra volumeMounts for the Upgrade CRDs Job. Optional.
@@ -369,6 +377,11 @@ upgradeCRDs: true
 # This job is meant primarily for cleaning up CRDs on CI systems.
 # Using this on production systems, especially those that have multiple releases of Velero, will be destructive.
 cleanUpCRDs: false
+
+cleanUpCRDsJob:
+  # Specifies the number of retries before marking the cleanup CRDs job as failed.
+  # See: https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy
+  backoffLimit: 3
 
 ##
 ## End of deployment-related settings.


### PR DESCRIPTION
## Description
This PR makes the `backoffLimit` configurable for Velero's Helm job resources, allowing users to adjust retry limits based on their environment needs.

## Motivation
The current hardcoded `backoffLimit` of 3 may be insufficient in environments with:
- Slow image registries or pull times
- Network latency issues  
- Resource constraints causing temporary pod failures
- Image pull authentication delays

This is particularly problematic for the `velero-upgrade-crds` job which runs as a Helm pre-install/pre-upgrade hook and can cause installation failures when it exceeds the backoff limit.

## Changes
- Added `upgradeCRDsJob.backoffLimit` configuration (default: 3)
- Added `cleanUpCRDsJob.backoffLimit` configuration (default: 3)
- Added `labelNamespaceJob.backoffLimit` configuration (default: 3)
- Updated all job templates to use these configurable values

## Backward Compatibility
✅ All defaults are set to 3, maintaining current behavior.

## Usage
Users can now override the backoff limit in their values:
```yaml
upgradeCRDsJob:
  backoffLimit: 10

cleanUpCRDsJob:
  backoffLimit: 5

labelNamespaceJob:
  backoffLimit: 5
```

## Testing
- [ ] Helm template rendering works correctly
- [ ] Default values maintain backward compatibility
- [ ] Custom values are properly applied to job specs

## Related Issues
Addresses scenarios where users encounter `BackoffLimitExceeded` errors during Velero installation.