### PR TITLE
velero - add veleroAnnotations to allow for unique annotations to ONLY be added to the velero pod. Signed-off-by: Brian Vacha <16612830+Brian-V@users.noreply.github.com>

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.17.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 11.3.2
+version: 11.3.3
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -42,8 +42,11 @@ spec:
         {{- if .Values.podLabels }}
           {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
-    {{- if or .Values.podAnnotations .Values.metrics.enabled (and .Values.credentials.useSecret (not .Values.credentials.existingSecret)) }}
+    {{- if or .Values.veleroAnnotations .Values.podAnnotations .Values.metrics.enabled (and .Values.credentials.useSecret (not .Values.credentials.existingSecret)) }}
       annotations:
+      {{- with .Values.veleroAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -39,7 +39,10 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
-# Annotations to add to the Velero deployment's. Optional.
+# Annotations to add to only Velero deployment pod. Optional.
+veleroAnnotations: {}
+
+# Annotations to add to all Velero deployment's (the deployment and daemonset pods). Optional.
 #
 # If you are using reloader use the following annotation with your VELERO_SECRET_NAME
 annotations: {}


### PR DESCRIPTION
#### Special notes for your reviewer:

This update is necessary for our deployment environment, where we use Karpenter autoscaler with aggressive node rebalancing. This Karpenter configuration regularly moves the velero controller pod during backups. Since any disruption causes the backup and all logs to fail, the velero pod, and only the velero pod, needs to have a special Karpenter-specific annotation. Currently, there's not another annotation we can add through the Helm chart that would only apply to the controller and not both the controller and daemonset pods.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
