### PR TITLE
fix(velero): pin kubectl image to official registry for k8s 1.34 and 1.35

### DIFF
--- a/charts/velero/templates/_helpers.tpl
+++ b/charts/velero/templates/_helpers.tpl
@@ -116,3 +116,16 @@ Calculate the checksum of the credentials secret.
 {{- define "chart.config-checksum" -}}
 {{- tpl (print .Values.credentials.secretContents .Values.credentials.extraEnvVars ) $ | sha256sum -}}
 {{- end -}}
+{{/*
+Kubectl image tag
+- If user explicitly sets kubectl.image.tag → use as-is
+- Otherwise infer from Kubernetes version and prefix with 'v'
+- Use Major.Minor inferred version and append '.0'
+*/}}
+{{- define "velero.kubectlImageTag" -}}
+{{- if .Values.kubectl.image.tag -}}
+{{- .Values.kubectl.image.tag -}}
+{{- else -}}
+{{- printf "v%s.0" (template "chart.KubernetesVersion" .) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/velero/templates/cleanup-crds.yaml
+++ b/charts/velero/templates/cleanup-crds.yaml
@@ -41,10 +41,8 @@ spec:
         - name: kubectl
           {{- if .Values.kubectl.image.digest }}
           image: "{{ .Values.kubectl.image.repository }}@{{ .Values.kubectl.image.digest }}"
-          {{- else if .Values.kubectl.image.tag }}
-          image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
           {{- else }}
-          image: "{{ .Values.kubectl.image.repository }}:{{ template "chart.KubernetesVersion" . }}"
+          image: "{{ .Values.kubectl.image.repository }}:{{ include "velero.kubectlImageTag" . }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:

--- a/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
@@ -44,10 +44,8 @@ spec:
         - name: kubectl
           {{- if .Values.kubectl.image.digest }}
           image: "{{ .Values.kubectl.image.repository }}@{{ .Values.kubectl.image.digest }}"
-          {{- else if .Values.kubectl.image.tag }}
-          image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
           {{- else }}
-          image: "{{ .Values.kubectl.image.repository }}:{{ template "chart.KubernetesVersion" . }}"
+          image: "{{ .Values.kubectl.image.repository }}:{{ include "velero.kubectlImageTag" . }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -343,7 +343,7 @@ metrics:
 
 kubectl:
   image:
-    repository: docker.io/bitnamilegacy/kubectl
+    repository: registry.k8s.io/kubectl
     # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
     # If used, it will take precedence over the kubectl.image.tag.
     # digest:


### PR DESCRIPTION

Velero upgrade/cleanup jobs were failing on Kubernetes 1.34 and 1.35 due to the default kubectl image resolving to docker.io/bitnamilegacy/kubectl:1.34, and docker.io/bitnamilegacy/kubectl:1.35, which does not exist. The Bitnami legacy kubectl repository is frozen and only publishes images up to Kubernetes 1.33.

This change explicitly pins the kubectl image to the official Kubernetes registry (registry.k8s.io/kubectl) with a compatible version, preventing ErrImagePull failures and making the deployment resilient to future Kubernetes upgrades.

No functional behavior change beyond fixing image pull failures.

Issue raised - https://github.com/vmware-tanzu/helm-charts/issues/727

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [ ] Variables are documented in the values.yaml or README.md
- [ ] Title of the PR starts with chart name (e.g. `[velero]`)
