### PR TITLE
[velero] fix missing deployment selector

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.18.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 12.0.0
+version: 12.0.1
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
     type: Recreate
   selector:
     matchLabels:
+      name: velero
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/name: {{ include "velero.name" . }}
   template:


### PR DESCRIPTION
previous velero deployment selector also match node-agent pods:

```
kubectl get pods --selector=app.kubernetes.io/instance=velero,app.kubernetes.io/name=velero
NAME                      READY   STATUS    RESTARTS       AGE
node-agent-4xp65          1/1     Running   0              22h
node-agent-gbsjf          1/1     Running   0              22h
…
velero-768f8b5b6d-2x79l   1/1     Running   0              22h
```

```
kubectl exec -it deploy/velero -c velero -- /velero version
Error from server (BadRequest): container velero is not valid for pod node-agent-hccs4
```


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
