### PR TITLE
[velero] Add nodeAgent.nodeAgentConfigMap for --node-agent-configmap

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.18.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 12.0.0
+version: 12.0.1
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/node-agent-daemonset.yaml
+++ b/charts/velero/templates/node-agent-daemonset.yaml
@@ -112,6 +112,9 @@ spec:
           args:
             - node-agent
             - server
+          {{- with .Values.nodeAgent.nodeAgentConfigMap }}
+            - --node-agent-configmap={{ . }}
+          {{- end }}
           {{- with .Values.configuration }}
             {{- with .features }}
             - --features={{ . }}

--- a/charts/velero/values.schema.json
+++ b/charts/velero/values.schema.json
@@ -673,6 +673,9 @@
                 "runtimeClassName": {
                     "type": "string"
                 },
+                "nodeAgentConfigMap": {
+                    "type": "string"
+                },
                 "resources": {
                     "type": "object",
                     "properties": {},

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -654,6 +654,12 @@ snapshotsEnabled: true
 deployNodeAgent: false
 
 nodeAgent:
+  # Optional ConfigMap name for node-agent data-path configuration (e.g. podLabels for
+  # data mover and PVB/PVR hosting pods). When non-empty, adds --node-agent-configmap to
+  # the node-agent container. Requires Velero v1.18+ (see vmware-tanzu/velero#9452).
+  # Leave empty to omit the flag.
+  nodeAgentConfigMap: ""
+
   # Disables Host Path volumes for node-agent.
   disableHostPath: false
   podVolumePath: /var/lib/kubelet/pods


### PR DESCRIPTION
Expose Velero v1.18+ node-agent ConfigMap flag so hosting pod labels/annotations from a ConfigMap are applied when users supply the map via `extraObjects` (or another mechanism).

**Refs:** https://github.com/vmware-tanzu/velero/pull/9452  
**Related:** https://github.com/vmware-tanzu/velero/issues/9435  
**Fixes:** https://github.com/vmware-tanzu/helm-charts/issues/733

### Changes

- Add optional `nodeAgent.nodeAgentConfigMap` (default `""`); when set, the node-agent DaemonSet receives `--node-agent-configmap=<name>`.
- Document the value in `values.yaml` and extend `values.schema.json`.
- Bump chart version `12.0.0` → `12.0.1`.

#### Special notes for your reviewer:

- Empty `nodeAgentConfigMap` omits the flag (backward compatible).
- Users who already pass the flag via `nodeAgent.extraArgs` can migrate to this value or keep using `extraArgs`.

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
