### PR TITLE
[velero] Add support for backup storage location sync period configuration

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.18.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 12.0.0
+version: 12.0.1
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/ci/test-values.yaml
+++ b/charts/velero/ci/test-values.yaml
@@ -14,6 +14,7 @@ configuration:
   - name: backups-secondary
     bucket: velero-backups
     provider: aws
+    backupSyncPeriod: "3h"
     config:
       region: us-west-1
       profile: us-west-1-profile

--- a/charts/velero/templates/backupstoragelocation.yaml
+++ b/charts/velero/templates/backupstoragelocation.yaml
@@ -37,6 +37,9 @@ spec:
   {{- with .validationFrequency }}
   validationFrequency: {{ . }}
   {{- end }}
+  {{- with .backupSyncPeriod }}
+  backupSyncPeriod: {{ . }}
+  {{- end }}
   objectStorage:
     bucket: {{ .bucket | quote }}
     {{- with .prefix }}

--- a/charts/velero/values.schema.json
+++ b/charts/velero/values.schema.json
@@ -382,6 +382,9 @@
                             "validationFrequency": {
                                 "type": ["string", "null"]
                             },
+                            "backupSyncPeriod": {
+                                "type": ["string", "null"]
+                            },
                             "accessMode": {
                                 "type": ["string", "null"]
                             },

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -398,6 +398,8 @@ configuration:
     default: false
     # validationFrequency defines how frequently Velero should validate the object storage. Optional.
     validationFrequency:
+    # backupSyncPeriod defines how frequently Velero should synchronize backups in object storage. Optional.
+    backupSyncPeriod:
     # accessMode determines if velero can write to this backup storage location. Optional.
     # default to ReadWrite, ReadOnly is used during migrations and restores.
     accessMode: ReadWrite


### PR DESCRIPTION
#### Special notes for your reviewer:
* Add the ability to set `backupSyncPeriod` on [`BackupStorageLocation` resources](https://velero.io/docs/main/api-types/backupstoragelocation/#main-config-parameters)

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
