### PR TITLE
fix(velero): use fullname helper for Deployment and supporting resources

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.18.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 12.0.1
+version: 12.0.2
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/cleanup-crds.yaml
+++ b/charts/velero/templates/cleanup-crds.yaml
@@ -22,7 +22,6 @@ spec:
   backoffLimit: 3
   template:
     metadata:
-      name: velero-cleanup-crds
       {{- with .Values.kubectl.labels }}
       labels:
         {{- toYaml . | nindent 8 }}

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: velero
+  name: {{ include "velero.fullname" . }}
   namespace: {{ .Release.Namespace }}
   {{- with .Values.annotations }}
   annotations:
@@ -181,7 +181,7 @@ spec:
             {{- end }}
             {{- with .repositoryMaintenanceJob }}
             {{- if and .repositoryConfigData (or .repositoryConfigData.global .repositoryConfigData.repositories) }}
-            - --repo-maintenance-job-configmap={{ default "velero-repo-maintenance" .repositoryConfigData.name }}
+            - --repo-maintenance-job-configmap={{ default (printf "%s-repo-maintenance" (include "velero.fullname" $)) .repositoryConfigData.name }}
             {{- else }}
             {{- end }}
             {{- end }}

--- a/charts/velero/templates/node-agent-daemonset.yaml
+++ b/charts/velero/templates/node-agent-daemonset.yaml
@@ -4,7 +4,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: node-agent
+  name: {{ include "velero.fullname" . }}-node-agent
   namespace: {{ .Release.Namespace }}
   {{- with .Values.nodeAgent.annotations }}
   annotations:

--- a/charts/velero/templates/podmonitor.yaml
+++ b/charts/velero/templates/podmonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: node-agent
+  name: {{ include "velero.fullname" . }}-node-agent
   {{- if .Values.metrics.nodeAgentPodMonitor.namespace }}
   namespace: {{ .Values.metrics.nodeAgentPodMonitor.namespace }}
   {{- end }}

--- a/charts/velero/templates/repo-maintenance-configmap.yaml
+++ b/charts/velero/templates/repo-maintenance-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ default "velero-repo-maintenance" .Values.configuration.repositoryMaintenanceJob.repositoryConfigData.name }}
+  name: {{ default (printf "%s-repo-maintenance" (include "velero.fullname" .)) .Values.configuration.repositoryMaintenanceJob.repositoryConfigData.name }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}

--- a/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
@@ -22,7 +22,6 @@ spec:
   backoffLimit: 3
   template:
     metadata:
-      name: velero-upgrade-crds
       {{- with .Values.kubectl.labels }}
       labels:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
- Replaced hardcoded 'velero' name in Deployment metadata with 'velero.fullname' helper.
- Updated node-agent DaemonSet and PodMonitor to use 'fullname' helper.
- Updated repo-maintenance ConfigMap and its corresponding container flag to use dynamic naming.
- Removed hardcoded pod names from cleanup and upgrade Jobs to prevent naming conflicts.
- Bumped chart version to 12.0.2.
- issue: https://github.com/vmware-tanzu/helm-charts/issues/731

#### Special notes for your reviewer:

#### Checklist
 
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [ ] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
