### PR TITLE
[velero] Add missing standard Kubernetes labels

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.18.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 12.0.2
+version: 12.0.3
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/backupstoragelocation.yaml
+++ b/charts/velero/templates/backupstoragelocation.yaml
@@ -18,6 +18,7 @@ metadata:
     app.kubernetes.io/name: {{ include "velero.name" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/version: {{ $.Chart.AppVersion }}
     helm.sh/chart: {{ include "velero.chart" $ }}
 spec:
   {{- if not (empty .credential) }}

--- a/charts/velero/templates/configmaps.yaml
+++ b/charts/velero/templates/configmaps.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: {{ include "velero.name" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/version: {{ $.Chart.AppVersion }}
     helm.sh/chart: {{ include "velero.chart" $ }}
   {{- with $configMap.labels }}
     {{- toYaml . | nindent 4 }}

--- a/charts/velero/templates/node-agent-daemonset.yaml
+++ b/charts/velero/templates/node-agent-daemonset.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     helm.sh/chart: {{ include "velero.chart" . }}
     {{- with .Values.nodeAgent.labels }}
       {{- toYaml . | nindent 4 }}
@@ -30,6 +31,7 @@ spec:
         app.kubernetes.io/name: {{ include "velero.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
         helm.sh/chart: {{ include "velero.chart" . }}
       {{- if .Values.nodeAgent.podLabels }}
         {{- toYaml .Values.nodeAgent.podLabels | nindent 8 }}

--- a/charts/velero/templates/prometheusrule.yaml
+++ b/charts/velero/templates/prometheusrule.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ include "velero.chart" . }}
     {{- if .Values.metrics.prometheusRule.additionalLabels }}
     {{- toYaml .Values.metrics.prometheusRule.additionalLabels | nindent 4 }}
     {{- end }}

--- a/charts/velero/templates/schedule.yaml
+++ b/charts/velero/templates/schedule.yaml
@@ -13,6 +13,7 @@ metadata:
     app.kubernetes.io/name: {{ include "velero.name" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/version: {{ $.Chart.AppVersion }}
     helm.sh/chart: {{ include "velero.chart" $ }}
     {{- if $schedule.labels }}
       {{- toYaml $schedule.labels | nindent 4 }}

--- a/charts/velero/templates/service.yaml
+++ b/charts/velero/templates/service.yaml
@@ -12,6 +12,7 @@ metadata:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     helm.sh/chart: {{ include "velero.chart" . }}
     {{- with .Values.metrics.service.labels }}
       {{- toYaml . | nindent 4 }}

--- a/charts/velero/templates/volumesnapshotlocation.yaml
+++ b/charts/velero/templates/volumesnapshotlocation.yaml
@@ -18,6 +18,7 @@ metadata:
     app.kubernetes.io/name: {{ include "velero.name" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/version: {{ $.Chart.AppVersion }}
     helm.sh/chart: {{ include "velero.chart" $ }}
 spec:
   {{- if not (empty .credential) }}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -360,7 +360,7 @@ kubectl:
   labels: {}
   # Extra volumes for the upgrade/cleanup job. Optional.
   extraVolumes: []
-  # Extra volumeMounts for the upgrade/cleanup job.. Optional.
+  # Extra volumeMounts for the upgrade/cleanup job. Optional.
   extraVolumeMounts: []
 
 # This job upgrades the CRDs.


### PR DESCRIPTION
#### Special notes for your reviewer:
This PR adds missing standard Kubernetes recommended labels across template resources :

- The `app.kubernetes.io/version` label was present in `deployment.yaml` but missing from several other template resources.
- The `helm.sh/chart` label was present in all other template resources but was missing from `templates/prometheusrule.yaml`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
