### PR TITLE
[velero] Fix nodeAgent lifecycle option

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.18.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 12.0.3
+version: 12.0.4
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/templates/node-agent-daemonset.yaml
+++ b/charts/velero/templates/node-agent-daemonset.yaml
@@ -192,7 +192,7 @@ spec:
           {{- with .Values.nodeAgent.extraEnvVars }}
           {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.lifecycle }}
+          {{- if .Values.nodeAgent.lifecycle }}
           lifecycle: {{ toYaml .Values.nodeAgent.lifecycle | nindent 12 }}
           {{- end }}
           securityContext:


### PR DESCRIPTION
#### Special notes for your reviewer:
Fixed the lifecycle condition in `templates/node-agent-daemonset.yaml`. 
The condition now correctly checks `.Values.nodeAgent.lifecycle` instead of `.Values.lifecycle`. 
So the nodeAgent lifecycle is only rendered when the nodeAgent lifecycle is actually configured in `values.yaml`: 
https://github.com/vmware-tanzu/helm-charts/blob/beb24e2081a90f19949630e001cc37c760281c40/charts/velero/values.yaml#L747-L748
Not when the Velero deployment lifecycle is set.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
