### PR TITLE
[velero] Add optional PodDisruptionBudget

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.18.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 12.0.3
+version: 12.1.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/ci/test-values.yaml
+++ b/charts/velero/ci/test-values.yaml
@@ -43,6 +43,11 @@ serviceAccount:
   server:
     name: velero
 
+# Exercise the optional PodDisruptionBudget in CI install/upgrade
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
 # The Velero server
 # Annotations to Velero deployment
 annotations:

--- a/charts/velero/templates/poddisruptionbudget.yaml
+++ b/charts/velero/templates/poddisruptionbudget.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "velero.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.podDisruptionBudget.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+    component: velero
+    {{- with .Values.podDisruptionBudget.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "velero.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/velero/templates/poddisruptionbudget.yaml
+++ b/charts/velero/templates/poddisruptionbudget.yaml
@@ -1,5 +1,9 @@
 {{- if (.Values.podDisruptionBudget).enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "velero.fullname" . }}

--- a/charts/velero/templates/poddisruptionbudget.yaml
+++ b/charts/velero/templates/poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.podDisruptionBudget.enabled }}
+{{- if (.Values.podDisruptionBudget).enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -199,6 +199,19 @@ nodeSelector: {}
 # DNS configuration to use for the Velero deployment. Optional.
 dnsConfig: {}
 
+# Pod Disruption Budget for the Velero deployment. Optional.
+# Velero runs a single replica with a Recreate strategy by default, so this is
+# disabled by default. Enable it when running Velero with multiple replicas.
+podDisruptionBudget:
+  enabled: false
+  # minAvailable and maxUnavailable are mutually exclusive; set only one.
+  minAvailable: 1
+  maxUnavailable: ""
+  # See https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  # unhealthyPodEvictionPolicy: IfHealthyBudget
+  annotations: {}
+  labels: {}
+
 # Extra volumes for the Velero deployment. Optional.
 extraVolumes: []
 


### PR DESCRIPTION
velero runs a single replica by default, so this PDB is opt-in (`podDisruptionBudget.enabled: false`). It's handy once you scale to multiple replicas and want to keep a pod up during node drains and upgrades.

Supports `minAvailable`/`maxUnavailable`, an optional `unhealthyPodEvictionPolicy`, and extra annotations/labels. Bumped the chart to 12.1.0 and enabled it in `ci/test-values.yaml` so install/upgrade actually exercises it.

Ran `ct lint` and `ct install --upgrade` locally on kind, both pass.

- [x] DCO signed
- [x] Chart version bumped (12.0.3 -> 12.1.0)
- [x] Variables documented in the values.yaml
- [x] Title starts with `[velero]`