### PR TITLE
[velero] update velero chart to v1.18.2

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: 1.18.1
+appVersion: 1.18.2
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 12.1.0
+version: 12.1.1
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -27,7 +27,7 @@ namespace:
 # enabling node-agent). Required.
 image:
   repository: docker.io/velero/velero
-  tag: v1.18.1
+  tag: v1.18.2
   # Digest value example: sha256:73266e6bd7e2fe3f65fb20677d36c4a8df76d417d9ba76bd9932e0d983a776ec.
   # If used, it will take precedence over the image.tag.
   # digest:


### PR DESCRIPTION
#### Special notes for your reviewer:

This follows the Velero v1.18.2 patch release and only updates the chart metadata plus default server image tag.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [ ] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)