### PR TITLE
[velero] Support deploying plugins using Kubernetes Image Volumes

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.18.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for velero
 name: velero
-version: 12.1.0
+version: 12.2.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/charts/velero/README.md
+++ b/charts/velero/README.md
@@ -80,6 +80,32 @@ If a value needs to be added or changed, you may do so with the `upgrade` comman
 helm upgrade <RELEASE NAME> vmware-tanzu/velero --namespace <YOUR NAMESPACE> --reuse-values --set configuration.backupStorageLocation[0].provider=<NEW PROVIDER>
 ```
 
+##### Deploying plugins with Image Volumes
+
+Instead of copying each plugin binary with an init container, plugins can be
+mounted directly from their OCI image using [Image Volumes](https://kubernetes.io/docs/concepts/storage/volumes/#image)
+via the `plugins` value:
+
+```yaml
+plugins:
+  - image: velero/velero-plugin-for-aws:v1.13.1
+  - image: velero/velero-plugin-for-csi:v0.7.1
+```
+
+The plugin binary is mounted read-only under the plugin directory, where Velero
+discovers it. By default the binary is taken from `plugins/<name>` inside the
+image (the convention used by the Velero plugin images); override `subPath` per
+plugin if the binary lives elsewhere, or point it at a directory to expose
+several binaries from one image. Compared to `initContainers`, this avoids the
+sequential init container startup, removes the per-plugin CPU/memory tuning,
+and works with distroless plugin images (no `cp` or shell required).
+
+This requires the `ImageVolume` feature with `subPath` support, i.e. Kubernetes
+>= 1.33 (beta, enabled by default), and a container runtime that supports image
+volumes (e.g. containerd >= 2.1, CRI-O >= 1.33). `plugins` and `initContainers`
+can be combined, and at least one plugin provider must be supplied through
+either of them.
+
 #### Using Helm 2
 
 We're no longer supporting Helm v2 since it was deprecated in November 2020.

--- a/charts/velero/templates/_helpers.tpl
+++ b/charts/velero/templates/_helpers.tpl
@@ -106,6 +106,26 @@ Kubernetes version
 {{- end -}}
 
 {{/*
+Derive a normalized name for a plugin mounted as an image volume.
+Input: a dict with key "plugin" (one entry of .Values.plugins).
+Uses the explicit `name` if provided, otherwise the image name (the last path
+component of the reference, stripped of any tag and digest). The result is
+sanitized to a DNS-1123 label so it can be used as a volume name and as a
+mount sub-directory under the plugin directory.
+*/}}
+{{- define "velero.pluginName" -}}
+{{- $plugin := .plugin -}}
+{{- if $plugin.name -}}
+{{- $plugin.name -}}
+{{- else -}}
+{{- $ref := splitList "@" $plugin.image | first -}}
+{{- $lastComponent := splitList "/" $ref | last -}}
+{{- $name := splitList ":" $lastComponent | first -}}
+{{- $name | lower | replace "_" "-" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Calculate the checksum of the credentials secret.
 */}}
 {{- define "chart.config-checksum" -}}

--- a/charts/velero/templates/_helpers.tpl
+++ b/charts/velero/templates/_helpers.tpl
@@ -126,6 +126,20 @@ mount sub-directory under the plugin directory.
 {{- end -}}
 
 {{/*
+Validate that the target cluster supports the plugin deployment method.
+Mounting a plugin binary from an image volume via `subPath` requires the
+`ImageVolume` feature with subPath support, i.e. Kubernetes >= 1.33.
+When rendering offline, pass `--kube-version` to override the detected version.
+*/}}
+{{- define "velero.validatePlugins" -}}
+{{- if .Values.plugins -}}
+{{- if not (semverCompare ">=1.33.0-0" .Capabilities.KubeVersion.Version) -}}
+{{- fail (printf "velero: `plugins` mounts plugin binaries from image volumes via subPath, which requires Kubernetes >= 1.33, but the target cluster is %s. Use `initContainers` instead, or pass --kube-version when rendering offline." .Capabilities.KubeVersion.Version) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Calculate the checksum of the credentials secret.
 */}}
 {{- define "chart.config-checksum" -}}

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -213,6 +213,13 @@ spec:
           volumeMounts:
             - name: plugins
               mountPath: /plugins
+            {{- range $plugin := .Values.plugins }}
+            {{- $name := include "velero.pluginName" (dict "plugin" $plugin) }}
+            - name: plugin-{{ $name }}
+              mountPath: /plugins/{{ $name }}
+              subPath: {{ default (printf "plugins/%s" $name) $plugin.subPath }}
+              readOnly: true
+            {{- end }}
             {{- if .Values.credentials.useSecret }}
             - name: cloud-credentials
               mountPath: /credentials
@@ -283,6 +290,14 @@ spec:
         {{- end }}
         - name: plugins
           emptyDir: {}
+        {{- range $plugin := .Values.plugins }}
+        - name: plugin-{{ include "velero.pluginName" (dict "plugin" $plugin) }}
+          image:
+            reference: {{ $plugin.image }}
+            {{- with $plugin.pullPolicy }}
+            pullPolicy: {{ . }}
+            {{- end }}
+        {{- end }}
         - name: scratch
           emptyDir: {}
         {{- if .Values.containerSecurityContext.readOnlyRootFilesystem }}

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "velero.validatePlugins" . -}}
 {{/* 'securityContext' got renamed to 'podSecurityContext', merge both dicts into one for backward compatibility */}}
 {{- $podSecurityContext := merge (.Values.podSecurityContext | default dict) (.Values.securityContext | default dict) -}}
 apiVersion: apps/v1

--- a/charts/velero/values.schema.json
+++ b/charts/velero/values.schema.json
@@ -108,6 +108,27 @@
             "type": ["array", "string", "null"],
             "items": {}
         },
+        "plugins": {
+            "type": ["array", "null"],
+            "items": {
+                "type": "object",
+                "properties": {
+                    "image": {
+                        "type": "string"
+                    },
+                    "pullPolicy": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "subPath": {
+                        "type": "string"
+                    }
+                },
+                "required": ["image"]
+            }
+        },
         "podSecurityContext": {
             "type": "object",
             "properties": {},

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -136,6 +136,34 @@ initContainers:
   #     - mountPath: /target
   #       name: plugins
 
+# Plugins to add to the Velero deployment using Kubernetes Image Volumes
+# (https://kubernetes.io/docs/concepts/storage/volumes/#image), as an
+# alternative to `initContainers`. Each plugin's binary is mounted read-only
+# from its OCI image into the plugin directory, so there is no sequential init
+# container startup and it works with distroless plugin images (no `cp`/shell
+# required).
+#
+# Requires the `ImageVolume` feature with `subPath` support, i.e. Kubernetes
+# >= 1.33 (beta, enabled by default), and a container runtime that supports
+# image volumes (e.g. containerd >= 2.1, CRI-O >= 1.33).
+#
+# At least one plugin provider image is required, supplied through either
+# `initContainers` or `plugins`. The two mechanisms can be combined.
+plugins: []
+  # - image: velero/velero-plugin-for-aws:v1.13.1
+  #   # Image pull policy for the plugin image volume. Optional, defaults to the
+  #   # cluster default for the resolved reference (Always for tags, IfNotPresent
+  #   # for digests).
+  #   pullPolicy: IfNotPresent
+  #   # Name used for the generated volume and as the mount target under the
+  #   # plugin directory. Optional, defaults to the image name (the last path
+  #   # component without tag/digest). Must be unique across plugins.
+  #   name: velero-plugin-for-aws
+  #   # Path of the plugin binary inside the image, mounted read-only into the
+  #   # plugin directory. Optional, defaults to `plugins/<name>`. Set it to a
+  #   # directory to expose several binaries shipped by the same image.
+  #   subPath: plugins/velero-plugin-for-aws
+
 # SecurityContext to use for the Velero deployment. Optional.
 # Set fsGroup for `AWS IAM Roles for Service Accounts`
 # see more informations at: https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

Closes #742


**What this PR does / why we need it**:

Adds an optional `plugins` value to deploy Velero plugins using Kubernetes [Image Volumes](https://kubernetes.io/docs/concepts/storage/volumes/#image), as an alternative to `initContainers`:

```yaml
plugins:
  - image: velero/velero-plugin-for-aws:v1.13.1
  - image: velero/velero-plugin-for-csi:v0.7.1
```

For each entry the chart generates an `image` volume and mounts the plugin binary read-only under the plugin directory (`/plugins/<name>`). By default the binary is taken from `plugins/<name>` inside the image (the convention used by the Velero plugin images); `subPath` can be overridden per plugin when the binary lives elsewhere, or pointed at a directory to expose several binaries.

Only the plugin binary is exposed (via `subPath`), so unrelated executables in the plugin image are never picked up by Velero's recursive plugin scan.

#### Special notes for your reviewer:

- Opt-in and fully backward compatible: when `plugins` is empty the rendered manifest is unchanged, and `initContainers` keeps working. `plugins` and `initContainers` can be combined.
- Requires the `ImageVolume` feature with `subPath` support: Kubernetes >= 1.33 (beta, enabled by default) and a runtime such as containerd >= 2.1 / CRI-O >= 1.33.
- Only the Velero server Deployment is affected; the node-agent DaemonSet does not load Velero plugins.
- Pods that Velero creates dynamically are not broken by this change. The repository maintenance Job copies the server's `volumes`/`volumeMounts` (but not its `initContainers`): with `initContainers` the inherited `plugins` `emptyDir` arrives empty, whereas an image volume is self-populating, so the maintenance pod simply gets a harmless read-only mount of the plugin binary. It needs no plugins either way (kopia accesses storage natively via the BSL). Data mover "exposer" pods do not inherit the server volumes and load no plugins.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped, please refer to the [chart version instruction](https://github.com/vmware-tanzu/helm-charts/blob/main/RELEASE-INSTRUCT.md#guidelines)
- [x] Variables are documented in the values.yaml or README.md
- [x] Title of the PR starts with chart name (e.g. `[velero]`)
